### PR TITLE
Add the `:std:` role to the extension

### DIFF
--- a/exts/ferrocene_spec/__init__.py
+++ b/exts/ferrocene_spec/__init__.py
@@ -32,6 +32,13 @@ def setup(app):
     # to add a stylesheet from an extension.
     app.add_css_file("spec.css")
 
+    app.add_config_value(
+        name="spec_std_docs_url",
+        default="https://doc.rust-lang.org/stable/std",
+        rebuild="env",  # Rebuild the environment when this changes
+        types=[str],
+    )
+
     return {
         "version": "0",
         "parallel_read_safe": True,

--- a/exts/ferrocene_spec/std_role.py
+++ b/exts/ferrocene_spec/std_role.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 
 class StdRefRole(SphinxRole):
     def run(self):
-        url = f"https://doc.rust-lang.org/stable/std/?search={quote(self.text)}"
+        url = f"{self.env.config.spec_std_docs_url}/?search={quote(self.text)}"
 
         node = nodes.reference(internal=False, refuri=url)
         node += nodes.literal("", self.text)


### PR DESCRIPTION
This PR implements the `:std:` role in the extension, allowing linking to standard library items in the specification like this:

```rst
This is a link to :std:`core::any::Any`.
```

By default the link will point to https://doc.rust-lang.org/std, but it's possible to change the base URL at build time with the `-D spec_std_docs_url=https://example.com` flag. The role is already used in some of the exported documents.