### PR TITLE
Include paragraph numbers in `objects.inv`

### DIFF
--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -183,15 +183,14 @@ def get_objects(env):
     for kind in KINDS:
         storage = get_storage(env, kind)
         for item in storage.values():
-            search_name = item.search_name(env)
             result.append(
                 (
                     item.id,
-                    search_name if search_name is not None else item.id,
+                    item.display_name(env),
                     kind.NAME,
                     item.document,
                     item.anchor(),
-                    1 if search_name is not None else -1,
+                    1 if item.include_in_search() is not None else -1,
                 )
             )
 

--- a/exts/ferrocene_spec/definitions/code_terms.py
+++ b/exts/ferrocene_spec/definitions/code_terms.py
@@ -17,7 +17,10 @@ class CodeTerm:
     def anchor(self):
         return f"codeterm_{self.id}"
 
-    def search_name(self, env):
+    def include_in_search(self):
+        return True
+
+    def display_name(self, env):
         return self.id
 
 

--- a/exts/ferrocene_spec/definitions/paragraphs.py
+++ b/exts/ferrocene_spec/definitions/paragraphs.py
@@ -26,9 +26,11 @@ class Paragraph:
     def anchor(self):
         return self.id
 
-    def search_name(self, env):
-        # Exclude paragraph numbers from search
-        return None
+    def include_in_search(self):
+        return False
+
+    def display_name(self, env):
+        return self.number(env)
 
 
 def collect_items_in_document(app, nodes):

--- a/exts/ferrocene_spec/definitions/syntax.py
+++ b/exts/ferrocene_spec/definitions/syntax.py
@@ -17,7 +17,10 @@ class Syntax:
     def anchor(self):
         return f"syntax_{self.id}"
 
-    def search_name(self, env):
+    def include_in_search(self):
+        return True
+
+    def display_name(self, env):
         return self.id
 
 

--- a/exts/ferrocene_spec/definitions/terms.py
+++ b/exts/ferrocene_spec/definitions/terms.py
@@ -17,7 +17,10 @@ class Term:
     def anchor(self):
         return f"term_{self.id}"
 
-    def search_name(self, env):
+    def include_in_search(self):
+        return True
+
+    def display_name(self, env):
         return self.id
 
 


### PR DESCRIPTION
This PR includes paragraph numbers in the `objects.inv` output file, so that the rest of our internal tooling can access them.