### PR TITLE
Include hashes of the paragraph contents in objects.inv

### DIFF
--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -22,6 +22,9 @@ class DefIdNode(nodes.Element):
     def __init__(self, kind, text):
         super().__init__(def_kind=kind, def_text=text, def_id=id_from_text(text))
 
+    def astext(self):
+        return self["def_text"]
+
 
 class DefRefNode(nodes.Element):
     def __init__(self, kind, source_doc, text):
@@ -31,6 +34,9 @@ class DefRefNode(nodes.Element):
             ref_text=text,
             ref_target=id_from_text(text),
         )
+
+    def astext(self):
+        return self["ref_text"]
 
 
 class DefIdRole(SphinxRole):


### PR DESCRIPTION
These hashes will be used by ferrocene/ferrocene's tooling to create lockfiles, requiring tests to be updated whenever the contents of a paragraph change.