### PR TITLE
Fix syntax blocks losing our formatting

### DIFF
--- a/exts/ferrocene_spec/syntax_directive.py
+++ b/exts/ferrocene_spec/syntax_directive.py
@@ -10,7 +10,21 @@ class SyntaxDirective(SphinxDirective):
     has_content = True
 
     def run(self):
-        node = nodes.literal_block("", "")
+        # The first argument of creating any docutils node is the "raw source",
+        # which in theory is completely optional for our needs. That's why all
+        # the nodes we create pass an empty string (the default) to it.
+        #
+        # Still, this block is fairly special: to decide whether to perform
+        # syntax highlighting on a literal block, Sphinx compares the raw
+        # source with the output of the astext() method, and it highlights only
+        # if the two are equal.
+        #
+        # We had problems in the past with the heuristic randomly causing the
+        # syntax blocks to be highlighted by Sphinx (thus losing all our custom
+        # formatting). Thus, to avoid problems we set the raw source to
+        # something that will never appear in the astext() output (byte zero).
+        node = nodes.literal_block("\0")
+
         node["classes"].append("spec-syntax")
 
         for child in Parser("\n".join(self.content), self.env.docname).parse():


### PR DESCRIPTION
#12 seemingly caused syntax blocks to lose our custom formatting (which caused errors with linkchecker when importing into ferrocene/ferrocene). After investigating for a while, I discovered that the change to the `astext` method of `DefRefNode` in that PR changed [how a Sphinx heuristic decided whether to do Sphin's own highlighting on a block](https://github.com/sphinx-doc/sphinx/blob/873d9f6fdababb96f0763f538e85921f7d332b70/sphinx/writers/html.py#L444-L447).

This PR introduces a fairly hacky workaround. Since that heuristic was last changed back in 2008 I don't expect it to change in the foreseeable future. I guess we could propose a patch upstream to add a flag to "force" Sphinx not highlighting the block, but I'm not sure whether it's worth the effort.