### PR TITLE
Publish on spec.ferrocene.dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,6 @@ jobs:
         uses: ferrous-systems/shared-github-actions/github-pages@main
         with:
           path: build/html
+          cname: spec.ferrocene.dev
           token: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'


### PR DESCRIPTION
This PR configures GitHub Pages to publish the specification on https://spec.ferrocene.dev. Until the repository is public authentication will be required to access it.