### PR TITLE
Fix output directory in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ building:
 ./make.py -c
 ```
 
-The rendered version will be available in `build/dirhtml/`.
+The rendered version will be available in `build/html/`.
 
 ## Updating build dependencies
 


### PR DESCRIPTION
Missed this when I changed the output format from dirhtml to html in #8.