### PR TITLE
Add syntax for linking in angle brackets

### DIFF
--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -28,10 +28,15 @@ class DefIdNode(nodes.Element):
 
 class DefRefNode(nodes.Element):
     def __init__(self, kind, source_doc, text):
-        target = text
-        if "[" in text and "]" in text:
-            target = target[target.find("[") + 1 : target.rfind("]")]
+        if "<" in text and text.endswith(">"):
+            target_start = text.rfind("<")
+            target = text[target_start + 1 : len(text) - 1]
+            text = text[:target_start].rstrip()
+        elif "[" in text and "]" in text:
+            target = text[text.find("[") + 1 : text.rfind("]")]
             text = text.replace("[", "").replace("]", "")
+        else:
+            target = text
 
         super().__init__(
             ref_kind=kind,


### PR DESCRIPTION
This PR adds a third syntax for linking definitions, as documented in #22. The new syntax allows to set a different label than the link, by specifying both:

```rst
This :t:`label is custom <link>`!
```