### PR TITLE
Remove centering for rubrics

### DIFF
--- a/themes/ferrocene/static/ferrocene.css
+++ b/themes/ferrocene/static/ferrocene.css
@@ -182,7 +182,6 @@ h1:hover a.headerlink, h2:hover a.headerlink, h3:hover a.headerlink, h4:hover a.
 p.rubric {
     margin: 2em 0 1em 0;
     font-weight: 700;
-    text-align: center;
 }
 
 h1 + p.rubric, h2 + p.rubric, h3 + p.rubric, h4 + p.rubric, h5 + p.rubric, h6 + p.rubric {


### PR DESCRIPTION
This PR changes the style for rubrics by moving them to the left of the page, rather than centering them. This change is purely aesthetic, it's just that having them in the center IMO disrupts the flow of the page.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/2299951/180423260-3f17f439-e150-49cc-a05a-eb7c3ce249c0.png) | ![After](https://user-images.githubusercontent.com/2299951/180423310-be25541b-b19d-4c87-8952-07bcd5d282fe.png) |
