### PR TITLE
Fix typo in ownership example

### DIFF
--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -369,7 +369,7 @@ atomic ``42``.
    use core::sync::atomic::AtomicI32;
 
    let x: AtomicI32 = AtomicI32::new(42);
-   let x: AtomicI32 = y;
+   let y: AtomicI32 = x;
 
 :dp:`fls_7wm8lvfuiou`
 Type ``&i32`` is a by reference type. By the end of the second statement, ``x``


### PR DESCRIPTION
The existing example is incorrect, since it just shadows the `x` with undefined `y`:

```rust
use core::sync::atomic::AtomicI32;

let x: AtomicI32 = AtomicI32::new(42);
let x: AtomicI32 = y; // d-oh!
```

This tiny PR changes the last line to be correct and match textual description:

```rust
let y: AtomicI32 = x;
```