### PR TITLE
Fix core::ops::Drop missing colon typo

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1463,7 +1463,7 @@ drop type
 ^^^^^^^^^
 
 :dp:`fls_ot3e31kwixil`
-A :dt:`drop type` is a :t:`type` that implements the :std:`core::ops:Drop`
+A :dt:`drop type` is a :t:`type` that implements the :std:`core::ops::Drop`
 :t:`trait` or contains a :t:`field` that has a :t:`destructor`.
 
 .. _fls_68cl4paduzx2:

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -403,7 +403,7 @@ Destructors
 .. rubric:: Legality Rules
 
 :dp:`fls_9m0gszdle0qb`
-A :t:`drop type` is a :t:`type` that implements the :std:`core::ops:Drop`
+A :t:`drop type` is a :t:`type` that implements the :std:`core::ops::Drop`
 :t:`trait` or contains a :t:`field` that has a :t:`destructor`.
 
 :dp:`fls_4nkzidytpi6`
@@ -423,8 +423,8 @@ An :t:`uninitialized` :t:`object` is not :t:`dropped`.
 :t:`Dropping` an :t:`initialized` :t:`object` proceeds as follows:
 
 #. :dp:`fls_bync24y6gp93`
-   If the :t:`drop type` implements the :std:`core::ops:Drop` :t:`trait`, then
-   ``core::ops:Drop::drop()`` is invoked.
+   If the :t:`drop type` implements the :std:`core::ops::Drop` :t:`trait`, then
+   ``core::ops::Drop::drop()`` is invoked.
 
 #. :dp:`fls_jzancf72i95f`
    If the :t:`drop type` is an :t:`array type`, then its elements are


### PR DESCRIPTION
In few places `core::ops::Drop` trait is incorrectly referenced to as `core::ops:Drop`, with single colon. This PR fixes that typo.