### PR TITLE
Introduce and reference "C" term

### DIFF
--- a/src/ffi.rst
+++ b/src/ffi.rst
@@ -62,7 +62,7 @@ The :t:`ABI kind` indicates the :t:`ABI` of a :t:`construct`.
 The following :t:`[ABI]s` are supported:
 
 * :dp:`fls_x7ct9k82fpgn`
-  ``extern "C"`` - The default :t:`ABI` of C code, referred to as :dt:`extern
+  ``extern "C"`` - The default :t:`ABI` of :t:`C` code, referred to as :dt:`extern
   C ABI`.
 
 * :dp:`fls_a2d8ltpgtvn6`
@@ -91,7 +91,7 @@ include, but may not be limited to, the following:
   ``extern "aapcs"`` - The ARM :t:`ABI`.
 
 * :dp:`fls_36qrs2fxxvi7`
-  ``extern "cdecl"`` - The x86_32 :t:`ABI` of C code.
+  ``extern "cdecl"`` - The x86_32 :t:`ABI` of :t:`C` code.
 
 * :dp:`fls_6rtj6rwqxojh`
   ``extern "fastcall"`` - The ``fastcall`` :t:`ABI` that corresponds to MSVC's
@@ -101,14 +101,14 @@ include, but may not be limited to, the following:
   ``extern "stdcall"`` - The x86_32 :t:`ABI` of the Win32 API.
 
 * :dp:`fls_7t7yxh94wnbl`
-  ``extern "sysv64"`` - The x86_64 non-Windows :t:`ABI` of C code.
+  ``extern "sysv64"`` - The x86_64 non-Windows :t:`ABI` of :t:`C` code.
 
 * :dp:`fls_sxj4vy39sj4g`
   ``extern "vectorcall"`` - The ``vectorcall`` :t:`ABI` that corresponds to
   MSVC's ``__vectorcall`` and clang's ``__attribute__((vectorcall))``.
 
 * :dp:`fls_tyjs1x4j8ovp`
-  ``extern "win64"`` - The x86_64 Windows :t:`ABI` of C code.
+  ``extern "win64"`` - The x86_64 Windows :t:`ABI` of :t:`C` code.
 
 .. rubric:: Examples
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -817,6 +817,15 @@ byte characters.
 :dp:`fls_4yhag19z61bl`
 See ``ByteStringLiteral.``
 
+.. _fls_lfjgrkwra22i:
+
+C
+^
+
+:dp:`fls_d4q2ro4nsnop`
+:dt:`C` is the programming language described in the ISO/IEC 9899:2018
+International Standard.
+
 .. _fls_wenn1wdsicfz:
 
 C representation

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -833,7 +833,7 @@ C representation
 
 :dp:`fls_g9pdb06m5fto`
 :dt:`C representation` is a :t:`type representation` that lays out :t:`[type]s`
-such that they are interoperable with the C language.
+such that they are interoperable with the :t:`C` language.
 
 .. _fls_xeo59ol6uh5i:
 
@@ -5507,7 +5507,7 @@ union type
 ^^^^^^^^^^
 
 :dp:`fls_af2sscrep7mc`
-A :dt:`union type` is an :t:`abstract data type` similar to a C-like union.
+A :dt:`union type` is an :t:`abstract data type` similar to a :t:`C`-like union.
 
 :dp:`fls_fgvjogfz8ink`
 See :s:`UnionDeclaration`.

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -789,7 +789,7 @@ Union Type
 .. rubric:: Legality Rules
 
 :dp:`fls_nskmnzq95yqm`
-A :t:`union type` is an :t:`abstract data type` similar to a C-like union.
+A :t:`union type` is an :t:`abstract data type` similar to a :t:`C`-like union.
 
 :dp:`fls_1caus8ybmfli`
 The :t:`name` of a :t:`union field` shall denote a unique :t:`name` within the
@@ -1389,7 +1389,7 @@ does not change the :t:`layout` of the :t:`[field]s` themselves.
 
 :dp:`fls_8s1vddh8vdhy`
 :t:`C representation` lays out a :t:`type` such that the :t:`type` is
-interoperable with the C language.
+interoperable with the :t:`C` language.
 
 :dp:`fls_b005bktrkrxy`
 :t:`Default representation` makes no guarantees about the :t:`layout`.
@@ -1439,7 +1439,7 @@ representation` are those of its :t:`discriminant`.
 
 :dp:`fls_s9c0a0lg6c0p`
 The :t:`discriminant type` of an :t:`enum type` with :t:`C representation` is
-the :t:`type` of a C ``enum`` for the target platform's C :t:`ABI`.
+the :t:`type` of a :t:`C` ``enum`` for the target platform's :t:`C` :t:`ABI`.
 
 :dp:`fls_slhvf3gmqz4h`
 The :t:`discriminant type` of an :t:`enum type` with :t:`default representation`


### PR DESCRIPTION
I used an explicit edition (current latest), considering the Unicode glossary term also does that.

Closes #159.