### PR TITLE
Fix use of "binding", "local variable", "object", "temporary", "variable"

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -3436,7 +3436,7 @@ Method Call Expressions
 
 :dp:`fls_b7i26954j1hc`
 A :t:`method call expression` is an :t:`expression` that invokes a :t:`method`
-of an :t:`object`.
+of a :t:`variable`.
 
 :dp:`fls_jx3ryre0xs88`
 A :t:`receiver operand` is an :t:`operand` that denotes the :t:`value` whose
@@ -3515,10 +3515,10 @@ Field Access Expressions
 
 :dp:`fls_hr8qvwlhd9ts`
 A :t:`field access expression` is an :t:`expression` that accesses a :t:`field`
-of an :t:`object`.
+of a :t:`value`.
 
 :dp:`fls_s2vpn4ihenpe`
-A :t:`container operand` is an :t:`operand` that indicates the :t:`object` whose
+A :t:`container operand` is an :t:`operand` that indicates the :t:`value` whose
 :t:`field` is selected in a :t:`field access expression`.
 
 :dp:`fls_yeuayil6uxzx`

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -375,7 +375,7 @@ The following :t:`[expression]s` are :t:`[place expression]s`:
   expression`,
 
 * :dp:`fls_ya05djl1d154`
-  :t:`[Path expression]s` that resolve to a :t:`binding` or a :t:`static`.
+  :t:`[Path expression]s` that resolve to a :t:`static` or a :t:`variable`.
 
 :dp:`fls_4vxi1ji93dxb`
 A :t:`place expression context` is a :t:`construct` that requires a :t:`place
@@ -417,15 +417,15 @@ context]s`:
 :dp:`fls_konzgoybhfqm`
 A :t:`place expression` can be moved out of when it denotes
 
-* :dp:`fls_vk1xhvdaakh0`
-  A :t:`binding` which is not currently :t:`borrowed`, or
-
 * :dp:`fls_4bnbv7mqod57`
   A :t:`field` of a :t:`place expression` that can be moved out of and does not
   implement the :std:`core::ops::Drop` :t:`trait`, or
 
 * :dp:`fls_3xk3p1unbjy5`
-  A :t:`temporary` created for a :t:`value expression`.
+  A :t:`temporary` created for a :t:`value expression`, or
+
+* :dp:`fls_vk1xhvdaakh0`
+  A :t:`variable` which is not currently :t:`borrowed`.
 
 :dp:`fls_wuqjaigxdq3r`
 After a :t:`place expression` is moved out, the memory location it represented
@@ -444,8 +444,8 @@ expression]s`:
   A :t:`dereference expression` whose :t:`type` is ``*mut T``,
 
 * :dp:`fls_s4bhrpykzmm7`
-  A :t:`dereference expression` of a :t:`field` or :t:`binding` whose :t:`type`
-  is ``&mut T``,
+  A :t:`dereference expression` of a :t:`field` or a :t:`variable` whose
+  :t:`type` is ``&mut T``,
 
 * :dp:`fls_1tq2o2huda9l`
   A :t:`dereference expression` whose :t:`type` implements the
@@ -455,12 +455,12 @@ expression]s`:
   A :t:`field access expression` where the :t:`type` of the :t:`container
   operand` is :t:`mutable`,
 
-* :dp:`fls_m0gbw9myylv2`
-  A :t:`path expression` that resolves to a :t:`mutable binding` that is not
-  currently borrowed,
-
 * :dp:`fls_ilaqmj3hc5uv`
   A :t:`path expression` that resolves to a :t:`mutable static`,
+
+* :dp:`fls_m0gbw9myylv2`
+  A :t:`path expression` that resolves to a :t:`mutable variable` that is not
+  currently borrowed,
 
 * :dp:`fls_dcm3yr3y9y0a`
   A :t:`temporary` created for a :t:`value expression`.
@@ -557,7 +557,7 @@ Path Expressions
 A :t:`path expression` is an :t:`expression` that denotes a :t:`path`.
 
 :dp:`fls_t8bdzvtnv249`
-A :t:`path expression` that resolves to a :t:`binding` or a :t:`static` is a
+A :t:`path expression` that resolves to a :t:`static` or a :t:`variable` is a
 :t:`place expression`, otherwise it is a :t:`value expression`.
 
 :dp:`fls_gz67ju6l7uhn`
@@ -691,8 +691,8 @@ The :t:`value` of an :t:`async block expression` is a :t:`future`.
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_9ghp5yet75y6`
-The :t:`evaluation` of an :t:`async block expression` produces an anonymous
-:t:`object` that captures the related :t:`future`.
+The :t:`evaluation` of an :t:`async block expression` produces a :t:`temporary`
+that captures the related :t:`future`.
 
 .. rubric:: Examples
 
@@ -878,8 +878,8 @@ The :t:`dereference` is assignable when
   The :t:`operand` is of :t:`type` ``&mut T`` or ``*mut T``, and
 
 * :dp:`fls_llzt4s3uwt95`
-  The :t:`operand` is a :t:`binding` or a possibly nested :t:`field` of a
-  :t:`binding`, or
+  The :t:`operand` is a :t:`variable` or a possibly nested :t:`field` of a
+  :t:`variable`, or
 
 * :dp:`fls_908xdt291via`
   The :t:`operand` denotes a :t:`mutable place expression`.
@@ -2106,8 +2106,8 @@ The :t:`evaluation` of a :t:`basic assignment` proceeds as follows:
 
 #. :dp:`fls_9i0ctuo099bp`
    The :t:`value` denoted by the :t:`assignee operand` is :t:`dropped`, unless
-   the :t:`assignee operand` denotes an uninitialized :t:`binding` or an
-   uninitialized :t:`field` of a :t:`binding`.
+   the :t:`assignee operand` denotes an uninitialized :t:`variable` or an
+   uninitialized :t:`field` of a :t:`variable`.
 
 #. :dp:`fls_hc01gtvlxba`
    The :t:`value` of the :t:`value operand` is :t:`copied` or :t:`moved` into
@@ -2207,7 +2207,7 @@ The :t:`evaluation` of a :t:`destructuring assignment` proceeds as follows:
 #. :dp:`fls_n7nuj1lvpspc`
    Each :t:`value` denoted by the :t:`assignee operand` is :t:`dropped`
    in left-to-right order, unless the :t:`assignee operand` denotes an
-   uninitialized :t:`binding` or an uninitialized field of a :t:`binding`.
+   uninitialized :t:`variable` or an uninitialized field of a :t:`variable`.
 
 #. :dp:`fls_qb8u5skn8bc4`
    The :t:`value` of the :t:`value operand` is :t:`copied` or :t:`moved` into
@@ -4941,8 +4941,8 @@ A :t:`capturing expression` is either an :t:`async block expression` or a
 :t:`closure expression`.
 
 :dp:`fls_eca6tl7j0afx`
-A :t:`capture target` is either a :t:`binding` or a :t:`field` of a
-:t:`binding`.
+A :t:`capture target` is either a :t:`variable` or a :t:`field` of a
+:t:`variable`.
 
 :dp:`fls_e70ywb8191h`
 The :t:`capturing environment` of a :t:`capturing expression` consists of all

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -5763,6 +5763,15 @@ value expression
 :dp:`fls_mn6tcuz5j3p`
 A :dt:`value expression` is an :t:`expression` that represents a :t:`value`.
 
+.. _fls_aP9ZaU01Dsg5:
+
+value holder
+^^^^^^^^^^^^
+
+:dp:`fls_RssUVCMKCNBx`
+A :dt:`value holder` is either a :t:`constant`, a :t:`static`, or a 
+:t:`variable`.
+
 .. _fls_a5xof9jlpc2e:
 
 value operand

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -5781,7 +5781,8 @@ variable
 ^^^^^^^^
 
 :dp:`fls_9ab12k4vwsio`
-A :dt:`variable` is a placeholder for a value that is allocated on the stack.
+A :dt:`variable` is a placeholder for a :t:`value` that is allocated on the
+stack.
 
 .. _fls_q0xplb4tbzpq:
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -3656,7 +3656,7 @@ owner
 ^^^^^
 
 :dp:`fls_7vwwhberexeb`
-An :dt:`owner` is a :t:`variable` that holds a :t:`value`.
+An :dt:`owner` is a :t:`value holder` that holds a :t:`value`.
 
 .. _fls_1gmetz8qtr0l:
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -512,11 +512,11 @@ binding
 ^^^^^^^
 
 :dp:`fls_89qi3unjvwd7`
-A :dt:`binding` is a :t:`variable` of an :t:`identifier pattern` or a
-:t:`shorthand deconstructor` that binds a matched :t:`value`.
+A :dt:`binding` is a :t:`variable` of a :t:`binding pattern` that binds a
+matched :t:`value`.
 
 :dp:`fls_lujdci4bphek`
-See :c:`Binding`.
+See :s:`Binding`.
 
 .. _fls_glblhx8vzd3z:
 
@@ -1069,8 +1069,8 @@ constant
 ^^^^^^^^
 
 :dp:`fls_p8rjw2qok85b`
-A :dt:`constant` is an immutable :t:`object` that is not associated with a
-specific memory location.
+A :dt:`constant` is an immutable :t:`value` whose uses are substituted by the
+:t:`value`.
 
 :dp:`fls_hlouedpdg1zd`
 See :s:`ConstantDeclaration`.
@@ -1181,7 +1181,7 @@ container operand
 ^^^^^^^^^^^^^^^^^
 
 :dp:`fls_stjmobac6wyd`
-A :dt:`container operand` is an :t:`operand` that indicates the :t:`object`
+A :dt:`container operand` is an :t:`operand` that indicates the :t:`value`
 whose :t:`field` is selected in a :t:`field access expression`.
 
 :dp:`fls_hgm1ssicc8j4`
@@ -1356,8 +1356,8 @@ destruction
 ^^^^^^^^^^^
 
 :dp:`fls_58i2nfhxze3j`
-:dt:`Destruction` is the process of recovering resources associated with an
-:t:`object` as it goes out of scope.
+:dt:`Destruction` is the process of recovering resources associated with a
+:t:`value` as it goes out of scope.
 
 .. _fls_kwxpy451gtc:
 
@@ -1366,7 +1366,7 @@ destructor
 
 :dp:`fls_79pp7o1xooja`
 A :dt:`destructor` is an anonymous :t:`function` that performs the
-:t:`destruction` of an :t:`object` of a :t:`drop type`.
+:t:`destruction` of a :t:`value` of a :t:`drop type`.
 
 .. _fls_2fuu3zr9rn2q:
 
@@ -1481,7 +1481,7 @@ dropping
 ^^^^^^^^
 
 :dp:`fls_k4mguykh8ey`
-:dt:`Dropping` an :t:`object` is the act of invoking the :t:`destructor` of the
+:dt:`Dropping` a :t:`value` is the act of invoking the :t:`destructor` of the
 related :t:`type`.
 
 .. _fls_6uovyjjzh6km:
@@ -1816,7 +1816,7 @@ field access expression
 
 :dp:`fls_gdl348a04d15`
 A :dt:`field access expression` is an :t:`expression` that accesses a :t:`field`
-of an :t:`object`.
+of a :t:`value`.
 
 :dp:`fls_luetyuwu54d6`
 See :s:`FieldAccessExpression`.
@@ -2596,8 +2596,8 @@ initialization
 ^^^^^^^^^^^^^^
 
 :dp:`fls_xi07ycze6mo0`
-:dt:`Initialization` is the act of supplying an initial :t:`value` to an
-:t:`object`.
+:dt:`Initialization` is the act of supplying an initial :t:`value` to a
+:t:`constant`, a :t:`static`, or a :t:`variable`.
 
 .. _fls_pd30dl2envjn:
 
@@ -3033,8 +3033,7 @@ local variable
 ^^^^^^^^^^^^^^
 
 :dp:`fls_3inlcyi6444u`
-A :dt:`local variable` is a :t:`variable` that refers to a :t:`value` allocated
-directly on the stack.
+For :dt:`local variable`, see :t:`variable`.
 
 .. _fls_kdqa8zs8tk6g:
 
@@ -3272,7 +3271,7 @@ method call expression
 
 :dp:`fls_367sod24edts`
 A :dt:`method call expression` is an :t:`expression` that invokes a :t:`method`
-of an :t:`object`.
+of a :t:`variable`.
 
 :dp:`fls_ohhcvxcaqv11`
 See :s:`MethodCallExpression`.
@@ -3531,15 +3530,6 @@ numeric type
 :dp:`fls_cpdsj94l57af`
 A :dt:`numeric type` is a :t:`type` whose :t:`[value]s` denote numbers.
 
-.. _fls_p86xdprmatcj:
-
-object
-^^^^^^
-
-:dp:`fls_pwed0368vc09`
-An :dt:`object` relates a :t:`value` to a :t:`name`, and dictates how the value
-is initialized and modified.
-
 .. _fls_a226qzrb4iq9:
 
 object safe
@@ -3666,7 +3656,7 @@ owner
 ^^^^^
 
 :dp:`fls_7vwwhberexeb`
-An :dt:`owner` is an :t:`object` that holds a :t:`value`.
+An :dt:`owner` is a :t:`variable` that holds a :t:`value`.
 
 .. _fls_1gmetz8qtr0l:
 
@@ -4705,7 +4695,7 @@ slice
 ^^^^^
 
 :dp:`fls_p1sv01ml2ark`
-A :dt:`slice` is an :t:`object` of a :t:`slice type`.
+A :dt:`slice` is a :t:`value` of a :t:`slice type`.
 
 .. _fls_1s3a31o9zx1a:
 
@@ -4760,7 +4750,7 @@ static
 ^^^^^^
 
 :dp:`fls_srx4v1e20yxa`
-A :dt:`static` is an :t:`object` that is associated with a specific memory
+A :dt:`static` is a :t:`value` that is associated with a specific memory
 location.
 
 :dp:`fls_1b7gpk8e98pw`
@@ -4995,8 +4985,8 @@ temporary
 ^^^^^^^^^
 
 :dp:`fls_fathkxu9kxvw`
-A :dt:`temporary` is an anonymous :t:`object` that holds the result of some
-intermediate computation.
+A :dt:`temporary` is an anonymous :t:`variable` produced by some intermediate
+computation.
 
 .. _fls_ihv02usuziw8:
 
@@ -5194,7 +5184,7 @@ tuple struct
 ^^^^^^^^^^^^
 
 :dp:`fls_pdcpmapiq491`
-A :dt:`tuple struct` is an :t:`object` of a :t:`tuple struct type`.
+A :dt:`tuple struct` is a :t:`value` of a :t:`tuple struct type`.
 
 .. _fls_81mx81sy0qxv:
 
@@ -5791,7 +5781,7 @@ variable
 ^^^^^^^^
 
 :dp:`fls_9ab12k4vwsio`
-A :dt:`variable` is an :t:`object` that is a component of a stack frame.
+A :dt:`variable` is a placeholder for a value that is allocated on the stack.
 
 .. _fls_q0xplb4tbzpq:
 

--- a/src/index.rst
+++ b/src/index.rst
@@ -15,7 +15,7 @@ Ferrocene Language Specification
    types-and-traits
    patterns
    expressions
-   values-and-objects
+   values
    statements
    functions
    associated-items

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -32,20 +32,24 @@ Initialization
 
 .. rubric:: Legality Rules
 
+A :t:`value holder` is either a :t:`constant`, a :t:`static`, or a
+:t:`variable`.
+
 :dp:`fls_drfzu02bo7oe`
 :t:`Initialization` is the act of supplying an initial :t:`value` to a
-:t:`constant`, a :t:`static`, or a :t:`variable`.
+:t:`value holder`.
 
 :dp:`fls_wnhci8phdu4m`
-When an :t:`object` holds a :t:`value`, the :t:`object` is considered to be
-:dt:`initialized`.
+When a :t:`value holder` holds a :t:`value`, the :t:`value holder` is
+considered to be :dt:`initialized`.
 
 :dp:`fls_ch2lvm50olqd`
-When an :t:`object` lacks a :t:`value` or its :t:`value` has been transferred
-:t:`by move`, the :t:`object` is considered to be :dt:`uninitialized`.
+When a :t:`value holder` lacks a :t:`value` or its :t:`value` has been
+transferred :t:`by move`, the :t:`value holder` is considered to be
+:dt:`uninitialized`.
 
 :dp:`fls_46910buiwvv9`
-An :t:`object` shall be :t:`initialized` before it is used.
+A :t:`value holder` shall be :t:`initialized` before it is used.
 
 .. rubric:: Runtime Semantics
 
@@ -415,12 +419,12 @@ A :t:`destructor` is an anonymous :t:`function` that performs the
 related :t:`type`. Such an object is said to be :dt:`dropped`.
 
 :dp:`fls_gfvm70iqu1l4`
-An :t:`uninitialized` :t:`object` is not :t:`dropped`.
+An :t:`uninitialized` :t:`value hilder` is not :t:`dropped`.
 
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_l2xkdjeydqtx`
-:t:`Dropping` an :t:`initialized` :t:`object` proceeds as follows:
+:t:`Dropping` an :t:`initialized` :t:`value holder` proceeds as follows:
 
 #. :dp:`fls_bync24y6gp93`
    If the :t:`drop type` implements the :std:`core::ops::Drop` :t:`trait`, then

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -20,7 +20,7 @@ Ownership
 management model of Rust.
 
 :dp:`fls_ckcnkbb6y3cq`
-An :t:`owner` is a :t:`variable` that holds a :t:`value`.
+An :t:`owner` is a :t:`value holder` that holds a :t:`value`.
 
 :dp:`fls_ze0u9gfylmhn`
 A :t:`value` shall have only one :t:`owner`.

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -20,7 +20,7 @@ Ownership
 management model of Rust.
 
 :dp:`fls_ckcnkbb6y3cq`
-An :t:`owner` is an :t:`object` that holds a :t:`value`.
+An :t:`owner` is a :t:`variable` that holds a :t:`value`.
 
 :dp:`fls_ze0u9gfylmhn`
 A :t:`value` shall have only one :t:`owner`.
@@ -33,8 +33,8 @@ Initialization
 .. rubric:: Legality Rules
 
 :dp:`fls_drfzu02bo7oe`
-:t:`Initialization` is the act of supplying an initial :t:`value` to an
-:t:`object`.
+:t:`Initialization` is the act of supplying an initial :t:`value` to a
+:t:`constant`, a :t:`static`, or a :t:`variable`.
 
 :dp:`fls_wnhci8phdu4m`
 When an :t:`object` holds a :t:`value`, the :t:`object` is considered to be
@@ -392,8 +392,8 @@ Destruction
 .. rubric:: Legality Rules
 
 :dp:`fls_e7ucq87s806d`
-:t:`Destruction` is the process of recovering resources associated with an
-:t:`object` as it goes out of scope.
+:t:`Destruction` is the process of recovering resources associated with a
+:t:`value` as it goes out of scope.
 
 .. _fls_u2mzjgiwbkz0:
 
@@ -408,10 +408,10 @@ A :t:`drop type` is a :t:`type` that implements the :std:`core::ops::Drop`
 
 :dp:`fls_4nkzidytpi6`
 A :t:`destructor` is an anonymous :t:`function` that performs the
-:t:`destruction` of an :t:`object` of a :t:`drop type`.
+:t:`destruction` of a :t:`value` of a :t:`drop type`.
 
 :dp:`fls_wzuwapjqtyyy`
-:t:`Dropping` an :t:`object` is the act of invoking the :t:`destructor` of the
+:t:`Dropping` a :t:`value` is the act of invoking the :t:`destructor` of the
 related :t:`type`. Such an object is said to be :dt:`dropped`.
 
 :dp:`fls_gfvm70iqu1l4`

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -124,7 +124,7 @@ An :t:`identifier pattern` is :t:`irrefutable` when:
 
 * :dp:`fls_r2mb8v2lh3x0`
   It does not have a :t:`bound pattern` and its :t:`binding` does not resolve to
-  a :t:`constant`, an :t:`unit struct` or an :t:`unit enum variant`.
+  a :t:`constant`, an :t:`unit struct`, or an :t:`unit enum variant`.
 
 :dp:`fls_7oioaitb075g`
 If the :t:`identifier pattern` does not have a :t:`bound pattern`, then the
@@ -734,12 +734,12 @@ is a static error if a :t:`struct pattern` cannot be interpreted.
 
 :dp:`fls_wi3yo3z5mn5w`
 A :t:`shorthand deconstructor` binds the :t:`value` of a matched :t:`field` to a
-:t:`variable`. A :t:`shorthand deconstructor` with :t:`keyword` ``mut`` yields a
-:t:`mutable` :t:`variable`.
+:t:`binding`. A :t:`shorthand deconstructor` with :t:`keyword` ``mut`` yields a
+:t:`mutable` :t:`binding`.
 
 :dp:`fls_g5t53fj9ghk0`
 It is a static error if a :t:`shorthand deconstructor` has only :t:`keyword`
-``ref`` or :t:`keywords` ``ref`` ``mut``, and its :t:`variable` shadows a
+``ref`` or :t:`keywords` ``ref`` ``mut``, and its :t:`binding` shadows a
 :t:`constant`.
 
 :dp:`fls_5vjoxrgeq3bg`

--- a/src/statements.rst
+++ b/src/statements.rst
@@ -63,8 +63,8 @@ A :t:`let statement` is a :t:`statement` that introduces new :t:`[binding]s`
 produced by its :t:`pattern-without-alternation`.
 
 :dp:`fls_1prqh1trybwz`
-The :t:`type` of a :t:`binding` introduced by a :t:`let statement` is determined
-as follows:
+The :t:`type` of a :t:`variable` introduced by a :t:`let statement` is
+determined as follows:
 
 * :dp:`fls_djkm8r2iuu6u`
   If the :t:`let statement` appears with a :t:`type ascription`, then the
@@ -75,7 +75,7 @@ as follows:
   :t:`inferred` using :t:`type inference`.
 
 :dp:`fls_m8a7gesa4oim`
-The :t:`value` of a :t:`binding` introduced by a :t:`let statement` is
+The :t:`value` of a :t:`variable` introduced by a :t:`let statement` is
 determined as follows:
 
 * :dp:`fls_oaxnre7m9s10`
@@ -83,7 +83,7 @@ determined as follows:
   is the :t:`value` of the :t:`expression`.
 
 * :dp:`fls_t5bjwluyv8za`
-  If the :t:`let statement` lacks an :t:`expression`, then the :t:`binding`
+  If the :t:`let statement` lacks an :t:`expression`, then the :t:`variable`
   is uninitialized.
 
 :dp:`fls_iqar7vvtw22c`
@@ -102,7 +102,7 @@ The :t:`execution` of a :t:`let statement` proceeds as follows:
       The :t:`expression` is evaluated.
 
    #. :dp:`fls_7j4qlwg72ege`
-      The :t:`value` of the :t:`expression` is assigned to each :t:`binding`
+      The :t:`value` of the :t:`expression` is assigned to each :t:`variable`
       introduced by the :t:`let statement`.
 
 .. rubric:: Examples

--- a/src/values-and-objects.rst
+++ b/src/values-and-objects.rst
@@ -31,10 +31,6 @@ Two :t:`[value]s` :t:`overlap` when
 * :dp:`fls_eoak5mdl6ma`
   Both :t:`[value]s` are elements of the same :t:`array`.
 
-:dp:`fls_jmwhiz1qrtmy`
-An :t:`object` relates a :t:`value` to a :t:`name`, and dictates how the
-:t:`value` is initialized and modified.
-
 :dp:`fls_prxicw2q70lj`
 An :t:`object` is :t:`valid` when it has been :t:`initialized` by all reachable
 control flow paths.
@@ -62,9 +58,8 @@ Constants
 .. rubric:: Legality Rules
 
 :dp:`fls_5o5iu4j8in4l`
-A :t:`constant` is an :t:`immutable` :t:`object` that is not associated with a
-specific memory location. The address of a :t:`constant` may differ from other
-:t:`[object]s` derived from the same :t:`constant`.
+A :t:`constant` is an :t:`immutable` :t:`value` whose uses are substituted by
+the :t:`value`.
 
 :dp:`fls_3mhj0kkupwuz`
 An :t:`unnamed constant` is a :t:`constant` declared with character 0x5F (low
@@ -131,7 +126,7 @@ Statics
 .. rubric:: Legality Rules
 
 :dp:`fls_ibrmiwfypldh`
-A :t:`static` is an :t:`object` that is associated with a specific memory
+A :t:`static` is a :t:`value` that is associated with a specific memory
 location.
 
 :dp:`fls_mt94jvoot9dx`
@@ -209,8 +204,8 @@ Temporaries
 .. rubric:: Legality Rules
 
 :dp:`fls_awpw61yofckz`
-A :t:`temporary` is an anonymous :t:`object` that holds the result of some
-intermediate computation.
+A :t:`temporary` is an anonymous :t:`variable` produced by some intermediate
+computation.
 
 .. _fls_gho955gmob73:
 
@@ -220,7 +215,8 @@ Variables
 .. rubric:: Legality Rules
 
 :dp:`fls_hl5tnd9yy252`
-A :t:`variable` is an :t:`object` that is a component of a stack frame.
+A :t:`variable` is a placeholder for a :t:`value` that is allocated on the
+stack.
 
 :dp:`fls_vgi0gh5zmoiu`
 The following :t:`[construct]s` are :t:`[variable]s`:

--- a/src/values-and-objects.rst
+++ b/src/values-and-objects.rst
@@ -32,7 +32,7 @@ Two :t:`[value]s` :t:`overlap` when
   Both :t:`[value]s` are elements of the same :t:`array`.
 
 :dp:`fls_prxicw2q70lj`
-An :t:`object` is :t:`valid` when it has been :t:`initialized` by all reachable
+An :t:`value` is :t:`valid` when it has been :t:`initialized` by all reachable
 control flow paths.
 
 .. rubric:: Undefined Behavior
@@ -222,7 +222,7 @@ stack.
 The following :t:`[construct]s` are :t:`[variable]s`:
 
 * :dp:`fls_3p0sb9ppmg3w`
-  An anonymous :t:`temporary`.
+  A :t:`temporary`.
 
 * :dp:`fls_81dlbula47nu`
   A named :t:`binding`.
@@ -230,16 +230,12 @@ The following :t:`[construct]s` are :t:`[variable]s`:
 * :dp:`fls_adqfhc5k051x`
   A named :t:`function parameter`.
 
-:dp:`fls_xfiuc52r672i`
-A :t:`local variable` is a :t:`variable` that refers to a :t:`value` allocated
-directly on the stack.
-
 :dp:`fls_r9km9f969bu8`
-A :t:`local variable` shall be used only after it has been initialized through
-all reachable control flow paths.
+A :t:`variable` shall be used only after it has been initialized through all
+reachable control flow paths.
 
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_g8etd5lsgn9j`
-A :t:`local variable` is not initialized when allocated.
+A :t:`variable` is not initialized when allocated.
 

--- a/src/values.rts
+++ b/src/values.rts
@@ -5,8 +5,8 @@
 
 .. _fls_94a8v54bufn8:
 
-Values and Objects
-==================
+Values
+======
 
 .. rubric:: Legality Rules
 


### PR DESCRIPTION
This PR updates the glossary in the following manner:

- Removes the term "object".
- Updates the definition of terms "binding", "constant", "local", "local variable", "static", "temporary", and "variable".

As a consequence, the PR also updates the uses of the aforementioned terms in relevant chapters.

Fixes [#58](https://github.com/ferrocene/specification/issues/58)