### PR TITLE
Fix various errors in the lexical elements chapter around escapes

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -820,7 +820,7 @@ byte string literal
 ^^^^^^^^^^^^^^^^^^^
 
 :dp:`fls_my4r1l3ilyt2`
-A :dt:`byte string literal` is a :t:`literal` that consists of multiple :s:`AsciiCharacter`s.
+A :dt:`byte string literal` is a :t:`literal` that consists of multiple :s:`[AsciiCharacter]s`.
 
 :dp:`fls_4yhag19z61bl`
 See :s:`ByteStringLiteral`.
@@ -4623,7 +4623,7 @@ simple byte string literal
 
 :dp:`fls_XpbU4Up0Aza8`
 A :dt:`simple byte string literal` is a :t:`byte string literal` that consists of multiple
-:s:`AsciiCharacter`.
+:s:`[AsciiCharacter]s`.
 
 :dp:`fls_OfI70zK68TnQ`
 See :s:`SimpleByteStringLiteral`.

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -611,7 +611,7 @@ Byte String Literals
 .. rubric:: Legality Rules
 
 :dp:`fls_t63zfv5JdUhj`
-A :t:`byte string literal` is a :t:`literal` that consists of multiple :s:`AsciiCharacter`s.
+A :t:`byte string literal` is a :t:`literal` that consists of multiple :s:`[AsciiCharacter]s`.
 
 .. _fls_msbaxfC09VkK:
 
@@ -639,7 +639,7 @@ except characters 0x0D (carriage return), 0x22 (quotation mark), and 0x5C
 
 :dp:`fls_moe3zfx39ox2`
 A :t:`simple byte string literal` is a :t:`byte string literal` that consists of multiple
-:s:`AsciiCharacter`s.
+:s:`[AsciiCharacter]s`.
 
 :dp:`fls_vffxb6arj9jf`
 The :t:`type` of a :t:`simple byte string literal` of size ``N`` is ``&'static [u8;


### PR DESCRIPTION
- This removes the AsciiCharacter syntax definition, replacing it with a glossary entry bringing it into line with how we define the Unicode character set.
- Splits byte string literals and byte literals apart, as the current definitions have them overlap in an incorrect way.
- Adds missing AsciiEscape and ByteEscape with the `\x` prefix
- Splits AsciiEscape from UnicodeEscape, as these are different kinds of escapes.
- Fixes incorrect example code for character escapes, closes https://github.com/ferrocene/specification/issues/149.