### PR TITLE
Fixed typo

### DIFF
--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -113,7 +113,7 @@ Lexical Elements, Separators, and Punctuation
      | $$-=$$
      | $$*=$$
      | $$/=$$
-     | $$&=$$
+     | $$%=$$
      | $$^=$$
      | $$&=$$
      | $$|=$$


### PR DESCRIPTION
`&=` appears twice, the first `&=` should have been `%=`