### PR TITLE
Add a name `hashrocket` to `=>`

### DIFF
--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -392,7 +392,7 @@ The following names are used when referring to :t:`[punctuator]s`:
      - Right arrow
    * - :dp:`fls_oh62j9unw4mg`
      - ``=>``
-     - Fat arrow
+     - Fat arrow, Hashrocket
    * - :dp:`fls_g0tltt8qmbum`
      - ``#``
      - Pound


### PR DESCRIPTION
Add a name `hashrocket` to `=>`, as it is used in other languages such as Ruby, and can also be used as a symbol to represent a hashmap key-value pair when implementing some macro syntax.