### PR TITLE
Ensure paragraph IDs are present

### DIFF
--- a/exts/ferrocene_spec_lints/__init__.py
+++ b/exts/ferrocene_spec_lints/__init__.py
@@ -3,11 +3,12 @@
 
 import sphinx
 import typing
-from . import alphabetical_section_titles
+from . import alphabetical_section_titles, require_paragraph_ids
 
 
 def run_lints(app, env):
     alphabetical_section_titles.check(app, raise_error)
+    require_paragraph_ids.check(app, raise_error)
 
 
 def raise_error(message, *, location=None):
@@ -19,6 +20,7 @@ def setup(app):
     app.connect("env-check-consistency", run_lints)
 
     app.add_config_value("lint_alphabetical_section_titles", [], "", typing.List[str])
+    app.add_config_value("lint_no_paragraph_ids", [], "", typing.List[str])
 
     return {
         "version": "0",

--- a/exts/ferrocene_spec_lints/require_paragraph_ids.py
+++ b/exts/ferrocene_spec_lints/require_paragraph_ids.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: Critical Section GmbH
+
+from docutils import nodes
+from ferrocene_spec.definitions import DefIdNode
+
+
+def check(app, raise_error):
+    for document in app.env.found_docs:
+        doctree = app.env.get_doctree(document)
+        if document in app.config.lint_no_paragraph_ids:
+            check_does_not_have_ids(doctree, raise_error)
+        else:
+            check_has_ids(doctree, raise_error)
+
+
+def check_has_ids(node, raise_error):
+    is_paragraph = type(node) == nodes.paragraph
+
+    if is_paragraph and type(node.parent) == nodes.section:
+        should_have_id(node, "paragraph", raise_error)
+    elif is_paragraph and type(node.parent) == nodes.list_item:
+        should_have_id(node, "list item", raise_error)
+    elif is_paragraph and type(node.parent) == nodes.entry:
+        if node.parent.parent.index(node.parent) == 0:
+            should_have_id(node, "first cell of a table row", raise_error)
+        else:
+            should_not_have_id(
+                node,
+                "second or later cell of a table row",
+                raise_error,
+            )
+    elif type(node) == nodes.section:
+        if not any(name.startswith("fls_") for name in node["names"]):
+            raise_error("section should have an id", location=node)
+    else:
+        should_not_have_id(node, type(node).__name__, raise_error)
+
+    for child in node.children:
+        check_has_ids(child, raise_error)
+
+
+def check_does_not_have_ids(node, raise_error):
+    if type(node) == nodes.section:
+        if any(name.startswith("fls_") for name in node["names"]):
+            raise_error("section should not have an id", location=node)
+    else:
+        should_not_have_id(node, type(node).__name__, raise_error)
+
+    for child in node.children:
+        check_does_not_have_ids(child, raise_error)
+
+
+def should_have_id(node, what, raise_error):
+    if any(is_definition(child) for child in node.children[1:]):
+        raise_error(f"id in {what} is not the first element", location=node)
+    elif not len(node.children) or not is_definition(node.children[0]):
+        raise_error(f"{what} should have an id", location=node)
+
+
+def should_not_have_id(node, what, raise_error):
+    if any(is_definition(child) for child in node.children):
+        raise_error(f"{what} should not have an id", location=node)
+
+
+def is_definition(node):
+    return (
+        type(node) == DefIdNode
+        and node["def_kind"] == "paragraph"
+        and node["def_id"].startswith("fls_")
+    )

--- a/src/conf.py
+++ b/src/conf.py
@@ -63,3 +63,5 @@ html_short_title = "Language Specification"
 # -- Options for linting -----------------------------------------------------
 
 lint_alphabetical_section_titles = ["glossary"]
+
+lint_no_paragraph_ids = ["index"]

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -419,6 +419,7 @@ location cannot be modified. All :t:`[place expression]s` that are not
 A :t:`place expression context` is a :t:`construct` that may evaluate its
 :t:`operand` as a memory location.
 
+:dp:`fls_fzsrdrHnndRd`
 The following :t:`[construct]s` are :t:`[place expression
 context]s`:
 

--- a/src/macros.rst
+++ b/src/macros.rst
@@ -997,6 +997,7 @@ transcribed to the matched tokens in order, as follows:
      2
    }
 
+:dp:`fls_JinrPA0pMZCr`
 yields ``0;1;2;``
 
 :dp:`fls_95rn4cvgznmd`

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -32,6 +32,7 @@ Initialization
 
 .. rubric:: Legality Rules
 
+:dp:`fls_3QyMS128AUOr`
 A :t:`value holder` is either a :t:`constant`, a :t:`static`, or a
 :t:`variable`.
 


### PR DESCRIPTION
This PR adds a lint to ensure paragraph IDs are properly inserted:

* List items and paragraphs must have an ID as their first element and no other IDs.
* Table rows must have the ID in their first cell.
* Sections must have an ID.

If IDs are present outside those places warnings/errors will be emitted. This PR also fixes some warnings introduced by this lint.