### PR TITLE
Correct Send conditions for closure captures

### DIFF
--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -869,8 +869,8 @@ A :t:`closure type` implicitly implements the :std:`core::marker::Send`
 
 * :dp:`fls_vamgwed199ct`
   The :t:`[type]s` of all :t:`[capture target]s` that employ :t:`by immutable
-  reference`, :t:`by mutable reference`, or :t:`by move` :t:`capture mode`
-  implement the :std:`core::marker::Sync` :t:`trait`, and
+  reference` or by :t:`by mutable reference` implement the
+  :std:`core::marker::Sync` :t:`trait`, and
 
 * :dp:`fls_f96a5r1v7te7`
   The :t:`[type]s` of all :t:`[capture target]s` that employ :t:`by unique


### PR DESCRIPTION
If a closure's by-move captures are Send but not Sync, the closure can still be Send.

[Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=a2d1fa6212d2ab1b486fe5823fcc70a7)

```rust
fn expect_send(_: &impl Send) {}
fn expect_sync(_: &impl Sync) {}

struct Foo(*mut ());
unsafe impl Send for Foo {}

fn main() {
    let foo = Foo(0x0 as _);
    expect_send(&foo);
    // Fails:
    // expect_sync(&foo);

    let cl = || {
        let _x = foo; // replace by &foo to fail
    };
    expect_send(&cl);
    // Fails:
    // expect_sync(&cl);
}
```