### PR TITLE
Mark informational pages in the source code

### DIFF
--- a/exts/ferrocene_spec/__init__.py
+++ b/exts/ferrocene_spec/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: Critical Section GmbH
 
-from . import definitions, syntax_directive, std_role, paragraph_ids
+from . import definitions, informational, syntax_directive, std_role, paragraph_ids
 from sphinx.domains import Domain
 
 
@@ -14,6 +14,7 @@ class SpecDomain(Domain):
     }
     directives = {
         "syntax": syntax_directive.SyntaxDirective,
+        "informational-page": informational.InformationalPageDirective,
     }
     object_types = definitions.get_object_types()
     indices = {}
@@ -35,6 +36,7 @@ def setup(app):
     app.add_domain(SpecDomain)
     definitions.setup(app)
     paragraph_ids.setup(app)
+    informational.setup(app)
 
     app.add_config_value(
         name="spec_std_docs_url",

--- a/exts/ferrocene_spec/informational.py
+++ b/exts/ferrocene_spec/informational.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: Critical Section GmbH
+
+from docutils import nodes
+from sphinx.directives import SphinxDirective
+from sphinx.environment.collectors import EnvironmentCollector
+from sphinx.transforms import SphinxTransform
+
+
+class InformationalPageDirective(SphinxDirective):
+    has_content = False
+
+    def run(self):
+        paragraph = nodes.paragraph()
+        paragraph += nodes.Text("The contents of this page are informational.")
+
+        note = nodes.note()
+        note += paragraph
+
+        return [note, InformationalMarkerNode()]
+
+
+class InformationalMarkerNode(nodes.Element):
+    pass
+
+
+class InformationalPagesCollector(EnvironmentCollector):
+    def clear_doc(self, app, env, docname):
+        storage = get_storage(env)
+        if docname in storage:
+            storage.remove(docname)
+
+    def merge_other(self, app, env, docnames, other):
+        storage = get_storage(env)
+        for element in get_storage(other):
+            storage.add(element)
+
+    def process_doc(self, app, document):
+        storage = get_storage(app.env)
+        for _ in document.findall(InformationalMarkerNode):
+            storage.add(app.env.docname)
+            break
+
+
+class RemoveInformationalMarkerNodesTransform(SphinxTransform):
+    default_priority = 500
+
+    def apply(self):
+        for node in self.document.findall(InformationalMarkerNode):
+            node.parent.remove(node)
+
+
+def get_storage(env):
+    key = "spec_informational"
+    if not hasattr(env, key):
+        setattr(env, key, set())
+    return getattr(env, key)
+
+
+def setup(app):
+    app.add_node(InformationalMarkerNode)
+    app.add_env_collector(InformationalPagesCollector)
+    app.add_post_transform(RemoveInformationalMarkerNodesTransform)

--- a/exts/ferrocene_spec/paragraph_ids.py
+++ b/exts/ferrocene_spec/paragraph_ids.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: Critical Section GmbH
 
-from . import definitions, utils
+from . import definitions, informational, utils
 from collections import defaultdict
 from docutils import nodes
 from sphinx.environment.collectors import EnvironmentCollector
@@ -47,6 +47,7 @@ def write_paragraph_ids(app):
                 "title": title.astext(),
                 "link": app.builder.get_target_uri(docname),
                 "sections": sections_by_document[docname],
+                "informational": docname in informational.get_storage(env),
             }
         )
 

--- a/src/general.rst
+++ b/src/general.rst
@@ -3,6 +3,8 @@
 
 .. default-domain:: spec
 
+.. informational-page::
+
 .. _fls_48qldfwwh493:
 
 General

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -3,6 +3,8 @@
 
 .. default-domain:: spec
 
+.. informational-page::
+
 .. _fls_bc2qwbfibrcs:
 
 Glossary

--- a/src/licenses.rst
+++ b/src/licenses.rst
@@ -3,6 +3,8 @@
 
 .. default-domain:: spec
 
+.. informational-page::
+
 .. _fls_kd7fcvfrwks0:
 
 Licenses


### PR DESCRIPTION
This PR adds a new directive, `informational-page`, which marks the page as informational. An informational page:

* ...will have a blue banner at the top explaining the page is informational.
* ...will be marked as such in `paragraph-ids.json`, so that the rest of our internal tooling can understand the page doesn't contain normative paragraphs.

![image](https://user-images.githubusercontent.com/2299951/186923388-5cbc71b6-2b3a-47af-a140-89cee5409bc5.png)
