### PR TITLE
dyn prefix is not optional in 2021 edition

### DIFF
--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1117,10 +1117,10 @@ Trait Object Types
 .. syntax::
 
    TraitObjectTypeSpecification ::=
-       $$dyn$$? TypeBoundList
+       $$dyn$$ TypeBoundList
 
    TraitObjectTypeSpecificationOneBound ::=
-       $$dyn$$? TraitBound
+       $$dyn$$ TraitBound
 
 .. rubric:: Legality Rules
 


### PR DESCRIPTION
Since we are going to target the 2021 edition specifically
Closes https://github.com/ferrocene/specification/issues/151