### PR TITLE
Change copyright to "Ferrous Systems and AdaCore"

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 # Configuration recommended by Black
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 # Sphinx ignored files
 /build

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 ====================================================
 Contributing to the Ferrocene Language Specification

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 ================================
 Ferrocene Language Specification

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 # Gate PRs on the GitHub Actions job "CI"
 status = ["CI"]

--- a/exts/ferrocene_appendices.py
+++ b/exts/ferrocene_appendices.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 from sphinx import addnodes as sphinxnodes

--- a/exts/ferrocene_spec/README.rst
+++ b/exts/ferrocene_spec/README.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 ====================
 FLS Sphinx Extension

--- a/exts/ferrocene_spec/__init__.py
+++ b/exts/ferrocene_spec/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText:  GmbH
 
 from . import definitions, informational, syntax_directive, std_role, paragraph_ids
 from sphinx.domains import Domain

--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from . import paragraphs, syntax, terms, code_terms
 from docutils import nodes

--- a/exts/ferrocene_spec/definitions/code_terms.py
+++ b/exts/ferrocene_spec/definitions/code_terms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec/definitions/paragraphs.py
+++ b/exts/ferrocene_spec/definitions/paragraphs.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from .. import utils
 from collections import defaultdict

--- a/exts/ferrocene_spec/definitions/syntax.py
+++ b/exts/ferrocene_spec/definitions/syntax.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec/definitions/terms.py
+++ b/exts/ferrocene_spec/definitions/terms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec/informational.py
+++ b/exts/ferrocene_spec/informational.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 from sphinx.directives import SphinxDirective

--- a/exts/ferrocene_spec/paragraph_ids.py
+++ b/exts/ferrocene_spec/paragraph_ids.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from . import definitions, informational, utils
 from collections import defaultdict

--- a/exts/ferrocene_spec/std_role.py
+++ b/exts/ferrocene_spec/std_role.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 from sphinx.roles import SphinxRole

--- a/exts/ferrocene_spec/syntax_directive.py
+++ b/exts/ferrocene_spec/syntax_directive.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from .definitions import DefIdNode, DefRefNode
 from docutils import nodes

--- a/exts/ferrocene_spec/utils.py
+++ b/exts/ferrocene_spec/utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec_lints/__init__.py
+++ b/exts/ferrocene_spec_lints/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 import sphinx
 import typing

--- a/exts/ferrocene_spec_lints/alphabetical_section_titles.py
+++ b/exts/ferrocene_spec_lints/alphabetical_section_titles.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 import re
 from docutils import nodes

--- a/exts/ferrocene_spec_lints/require_paragraph_ids.py
+++ b/exts/ferrocene_spec_lints/require_paragraph_ids.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 from docutils import nodes
 from ferrocene_spec.definitions import DefIdNode

--- a/generate-random-ids.py
+++ b/generate-random-ids.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 # Convenience script to generate a list of random paragraph IDs, ready to be
 # copy-pasted as you write new paragraphs.

--- a/make.py
+++ b/make.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 # Convenience script to build the Ferrocene Language Specification, including
 # setting up a Python virtual environment to install Sphinx into (removing the

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 sphinx
 sphinx-autobuild

--- a/requirements.txt.license
+++ b/requirements.txt.license
@@ -1,2 +1,2 @@
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: Critical Section GmbH
+SPDX-FileCopyrightText: Ferrous Systems and AdaCore

--- a/src/associated-items.rst
+++ b/src/associated-items.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/concurrency.rst
+++ b/src/concurrency.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 # -- Path setup --------------------------------------------------------------
 
@@ -12,8 +12,8 @@ sys.path.insert(0, os.path.abspath("../exts"))
 # -- Project information -----------------------------------------------------
 
 project = "Ferrocene Language Specification"
-copyright = "Critical Section GmbH"
-author = "Critical Section GmbH"
+copyright = "Ferrous Systems and AdaCore"
+author = "Ferrous Systems and AdaCore"
 
 
 # -- General configuration ---------------------------------------------------

--- a/src/exceptions-and-errors.rst
+++ b/src/exceptions-and-errors.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/ffi.rst
+++ b/src/ffi.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/functions.rst
+++ b/src/functions.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/general.rst
+++ b/src/general.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/generics.rst
+++ b/src/generics.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/implementations.rst
+++ b/src/implementations.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/index.rst
+++ b/src/index.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 Ferrocene Language Specification
 ================================

--- a/src/items.rst
+++ b/src/items.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/licenses.rst
+++ b/src/licenses.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/macros.rst
+++ b/src/macros.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/names-and-resolution.rst
+++ b/src/names-and-resolution.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/program-structure-and-compilation.rst
+++ b/src/program-structure-and-compilation.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/statements.rst
+++ b/src/statements.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/unsafety.rst
+++ b/src/unsafety.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/src/values.rst
+++ b/src/values.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 .. default-domain:: spec
 

--- a/themes/ferrocene/layout.html
+++ b/themes/ferrocene/layout.html
@@ -1,5 +1,5 @@
 {# SPDX-License-Identifier: MIT OR Apache-2.0 #}
-{# SPDX-FileCopyrightText: Critical Section GmbH #}
+{# SPDX-FileCopyrightText: Ferrous Systems and AdaCore #}
 
 {% extends "basic/layout.html" %}
 {% from "fontawesome.html" import icon_search %}

--- a/themes/ferrocene/search.html
+++ b/themes/ferrocene/search.html
@@ -1,5 +1,5 @@
 {# SPDX-License-Identifier: MIT OR Apache-2.0 #}
-{# SPDX-FileCopyrightText: Critical Section GmbH #}
+{# SPDX-FileCopyrightText: Ferrous Systems and AdaCore #}
 
 {% extends "basic/search.html" %}
 

--- a/themes/ferrocene/static/favicon.svg
+++ b/themes/ferrocene/static/favicon.svg
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: CC-BY-ND-4.0  -->
-<!-- SPDX-FileCopyrightText: Critical Section GmbH -->
+<!-- SPDX-FileCopyrightText: Ferrous Systems and AdaCore -->
 <!-- Please attribute this logo with: "Ferrocene is a registered trademark of Critical Section GmbH" -->
 <svg width="179" height="204" viewBox="0 0 179 204" fill="none" xmlns="http://www.w3.org/2000/svg">
 <style>

--- a/themes/ferrocene/static/ferrocene.css
+++ b/themes/ferrocene/static/ferrocene.css
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MIT OR Apache-2.0 */
-/* SPDX-FileCopyrightText: Critical Section GmbH */
+/* SPDX-FileCopyrightText: Ferrous Systems and AdaCore */
 
 /*************
  *   Fonts   *

--- a/themes/ferrocene/static/ferrocene.svg
+++ b/themes/ferrocene/static/ferrocene.svg
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: CC-BY-ND-4.0  -->
-<!-- SPDX-FileCopyrightText: Critical Section GmbH -->
+<!-- SPDX-FileCopyrightText: Ferrous Systems and AdaCore -->
 <!-- Please attribute this logo with: "Ferrocene is a registered trademark of Critical Section GmbH" -->
 <svg width="662" height="143" viewBox="0 0 662 143" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M95.2215 44.1856C94.3787 44.4987 93.4338 44.2418 92.8342 43.5721C85.3841 35.2498 74.5543 30.0118 62.5001 30.0118C50.4459 30.0118 39.616 35.2498 32.1659 43.5721C31.5664 44.2418 30.6215 44.4987 29.7786 44.1856L1.6883 33.7515C0.065425 33.1486 -0.519707 31.155 0.5203 29.7718L22.1295 1.03325C22.6186 0.38273 23.3855 0 24.1998 0L100.8 6.06625e-06C101.614 6.06625e-06 102.381 0.382738 102.871 1.03326L124.48 29.7719C125.52 31.155 124.935 33.1486 123.312 33.7515L95.2215 44.1856Z" fill="#194E80"/>

--- a/themes/ferrocene/theme.conf
+++ b/themes/ferrocene/theme.conf
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Critical Section GmbH
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
 [theme]
 inherit = basic


### PR DESCRIPTION
This changes the copyright notice to "Ferrous Systems
and AdaCore", indicating the joint work done.

The trademark notice for remains "Critical Section Gmbh",
indicating the legal holder of the trademark.