### PR TITLE
Add support for informational sections

### DIFF
--- a/exts/ferrocene_spec/__init__.py
+++ b/exts/ferrocene_spec/__init__.py
@@ -14,7 +14,8 @@ class SpecDomain(Domain):
     }
     directives = {
         "syntax": syntax_directive.SyntaxDirective,
-        "informational-page": informational.InformationalPageDirective,
+        "informational-page": informational.build_directive("page"),
+        "informational-section": informational.build_directive("section"),
     }
     object_types = definitions.get_object_types()
     indices = {}
@@ -49,4 +50,12 @@ def setup(app):
         "version": "0",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
+        # The version needs to be updated whenever there is a breaking change
+        # in the data stored in the environment. Bumping the version number
+        # will ensure Sphinx will do a clean build.
+        #
+        # Version history:
+        # - 0: initial implementation
+        # - 1: changed how informational sections and pages are stored
+        "env_version": "1",
     }

--- a/exts/ferrocene_spec/informational.py
+++ b/exts/ferrocene_spec/informational.py
@@ -1,45 +1,78 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 # SPDX-FileCopyrightText: Ferrous Systems and AdaCore
 
+from . import utils
+from collections import defaultdict
 from docutils import nodes
+from sphinx import addnodes
 from sphinx.directives import SphinxDirective
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.transforms import SphinxTransform
+import sphinx
 
 
-class InformationalPageDirective(SphinxDirective):
-    has_content = False
+# Marker to use inside the informational storage to signal the whole page, and
+# not just a section, is informational
+WHOLE_PAGE = "{{{whole-page}}}"
 
-    def run(self):
-        paragraph = nodes.paragraph()
-        paragraph += nodes.Text("The contents of this page are informational.")
 
-        note = nodes.note()
-        note += paragraph
+def build_directive(kind):
+    class InformationalDirective(SphinxDirective):
+        has_content = False
 
-        return [note, InformationalMarkerNode()]
+        def run(self):
+            paragraph = nodes.paragraph()
+            paragraph += nodes.Text(f"The contents of this {kind} are informational.")
+
+            note = nodes.note()
+            note += paragraph
+
+            return [note, InformationalMarkerNode(kind)]
+
+    return InformationalDirective
 
 
 class InformationalMarkerNode(nodes.Element):
-    pass
+    def __init__(self, kind):
+        super().__init__()
+        self["kind"] = kind
 
 
 class InformationalPagesCollector(EnvironmentCollector):
     def clear_doc(self, app, env, docname):
         storage = get_storage(env)
         if docname in storage:
-            storage.remove(docname)
+            del storage[docname]
 
     def merge_other(self, app, env, docnames, other):
         storage = get_storage(env)
-        for element in get_storage(other):
-            storage.add(element)
+        for document, contents in get_storage(other).items():
+            storage[document] = storage[document].union(contents)
 
     def process_doc(self, app, document):
         storage = get_storage(app.env)
-        for _ in document.findall(InformationalMarkerNode):
-            storage.add(app.env.docname)
-            break
+        for node in document.findall(InformationalMarkerNode):
+            if node["kind"] == "page":
+                self.process_page(app, storage, node)
+            elif node["kind"] == "section":
+                self.process_section(app, storage, node)
+            else:
+                raise RuntimeError("unknown directive kind: " + node["kind"])
+
+    def process_page(self, app, storage, node):
+        if type(node.parent) != addnodes.document:
+            warn("informational-page must be at the top of the document", node)
+            return
+
+        storage[app.env.docname].add(WHOLE_PAGE)
+
+    def process_section(self, app, storage, node):
+        if type(node.parent) != nodes.section:
+            warn("informational-section must be inside a section", node)
+            return
+
+        _id, anchor = utils.section_id_and_anchor(node.parent)
+        storage[app.env.docname].add(anchor)
 
 
 class RemoveInformationalMarkerNodesTransform(SphinxTransform):
@@ -53,8 +86,13 @@ class RemoveInformationalMarkerNodesTransform(SphinxTransform):
 def get_storage(env):
     key = "spec_informational"
     if not hasattr(env, key):
-        setattr(env, key, set())
+        setattr(env, key, defaultdict(set))
     return getattr(env, key)
+
+
+def warn(message, location):
+    logger = sphinx.util.logging.getLogger(__name__)
+    logger.warning(message, location=location)
 
 
 def setup(app):

--- a/exts/ferrocene_spec/paragraph_ids.py
+++ b/exts/ferrocene_spec/paragraph_ids.py
@@ -12,6 +12,8 @@ import sphinx
 
 def write_paragraph_ids(app):
     env = app.env
+    informational_storage = informational.get_storage(env)
+    print(informational_storage)
 
     paragraphs_by_section = defaultdict(list)
     for paragraph in definitions.get_storage(env, definitions.paragraphs).values():
@@ -37,6 +39,9 @@ def write_paragraph_ids(app):
                 "title": section.title,
                 "link": app.builder.get_target_uri(section.document) + section.anchor,
                 "paragraphs": paragraphs_by_section[section.id],
+                "informational": (
+                    section.anchor in informational_storage[section.document]
+                ),
             }
         )
 
@@ -47,7 +52,9 @@ def write_paragraph_ids(app):
                 "title": title.astext(),
                 "link": app.builder.get_target_uri(docname),
                 "sections": sections_by_document[docname],
-                "informational": docname in informational.get_storage(env),
+                "informational": (
+                    informational.WHOLE_PAGE in informational_storage[docname]
+                ),
             }
         )
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -48,6 +48,8 @@ those :t:`[value]s`.
 Type Classification
 -------------------
 
+.. informational-section::
+
 .. rubric:: Legality Rules
 
 :dp:`fls_c4xe3pkn0n3o`


### PR DESCRIPTION
Requested by @kirtchev-adacore, this allows marking individual sections rather than whole pages as informational, and marks the "Type Classification" section as informational.