### PR TITLE
Describe when temporaries are created in expressions

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -555,8 +555,9 @@ A :t:`value expression context` is an expression context that is not a
 :t:`place expression context`.
 
 :dp:`fls_8uhfwqurbyqf`
-The evaluation of a :t:`value expression` in a :t:`place expression context` may
-produce a :t:`temporary`.
+The evaluation of a :t:`value expression` in a :t:`place expression context`
+shall evaluate the :t:`value expression` as a :t:`temporary` and then use the
+:t:`temporary` in the :t:`place expression context`.
 
 .. _fls_h0dvogc64tfh:
 


### PR DESCRIPTION
This is only half of the picture, pattern matching can also introduce temporaries, but the rules there are more complex to describe