### PR TITLE
Handle sections without an ID

### DIFF
--- a/exts/ferrocene_spec/definitions/paragraphs.py
+++ b/exts/ferrocene_spec/definitions/paragraphs.py
@@ -5,6 +5,7 @@ from .. import utils
 from collections import defaultdict
 from docutils import nodes
 import hashlib
+import sphinx
 
 
 ROLE = "p"
@@ -49,7 +50,16 @@ def collect_items_in_document(app, nodes_to_collect):
         if section_node is None:
             raise RuntimeError(f"could not find section for {node!r}")
 
-        section_id, section_anchor = utils.section_id_and_anchor(section_node)
+        try:
+            section_id, section_anchor = utils.section_id_and_anchor(section_node)
+        except utils.NoSectionIdError:
+            logger = sphinx.util.logging.getLogger(__name__)
+            logger.warn(
+                "paragraph inside a section tha doesn't have an id starting with fls_",
+                location=node,
+            )
+            return
+
         yield Paragraph(
             id=node["def_id"],
             document=app.env.docname,

--- a/exts/ferrocene_spec/definitions/paragraphs.py
+++ b/exts/ferrocene_spec/definitions/paragraphs.py
@@ -55,7 +55,7 @@ def collect_items_in_document(app, nodes_to_collect):
         except utils.NoSectionIdError:
             logger = sphinx.util.logging.getLogger(__name__)
             logger.warn(
-                "paragraph inside a section tha doesn't have an id starting with fls_",
+                "paragraph inside a section that doesn't have an id starting with fls_",
                 location=node,
             )
             return

--- a/exts/ferrocene_spec/informational.py
+++ b/exts/ferrocene_spec/informational.py
@@ -71,7 +71,14 @@ class InformationalPagesCollector(EnvironmentCollector):
             warn("informational-section must be inside a section", node)
             return
 
-        _id, anchor = utils.section_id_and_anchor(node.parent)
+        try:
+            _id, anchor = utils.section_id_and_anchor(node.parent)
+        except utils.NoSectionIdError:
+            warn(
+                "informational-section must be inside a section with an ID "
+                "starting with fls_"
+            )
+            return
         storage[app.env.docname].add(anchor)
 
 


### PR DESCRIPTION
Reported in #296, if someone puts a paragraph with an ID inside a section without an ID, an exception happens because the extension can't link the paragraph with its parent section. This PR adds a warning explaining what the problem is and where it happen. Note that even with this patch, an exception will be raised down the line, but there will at least be a warning showing where the error comes from.

This also adds a `--debug` flag to `make.py` that shows the exception. Showing exceptions is behind a flag because showing exception with parallel builds enabled will result in an useless exception being reported due to how Sphinx's multiprocessing works. So, the `--debug` flag also disables parallel builds, which slows down things a lot.