### PR TITLE
Change conforming "implementation" to "tool"

### DIFF
--- a/src/general.rst
+++ b/src/general.rst
@@ -88,7 +88,7 @@ This document specifies:
   attempting to translate or execute a program containing such violations;
 
 * :dp:`fls_5pbrl8lhuth1`
-  The violations that a conforming implementation is not required to detect.
+  The violations that a conforming tool is not required to detect.
 
 :dp:`fls_o8fc3e53vp7g`
 This document does not specify:


### PR DESCRIPTION
This PR fixes the wording of *conforming implementation* to *conforming tool*. 

I think this might have been a typo, as the text refers to *conforming tool* in all places except this one.