### PR TITLE
Specify binding and variable without mutually referring to each other

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -585,8 +585,8 @@ binding
 ^^^^^^^
 
 :dp:`fls_89qi3unjvwd7`
-A :dt:`binding` is a :t:`variable` of a :t:`binding pattern` that binds a
-matched :t:`value`.
+A :dt:`binding` of a :t:`binding pattern` binds a matched :t:`value` to a
+:t:`name`.
 
 :dp:`fls_lujdci4bphek`
 See :s:`Binding`.

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -1164,8 +1164,8 @@ A :t:`binding pattern` is either an :t:`identifier pattern` or a :t:`shorthand
 deconstructor`.
 
 :dp:`fls_vnh9wfrvumdz`
-A :t:`binding` is a :t:`variable` of a :t:`binding pattern` that binds a matched
-:t:`value`.
+A :t:`binding` of a :t:`binding pattern` binds a matched :t:`value` to a
+:t:`name`.
 
 :dp:`fls_dqe75i8h2fie`
 A :t:`non-reference pattern` is any :t:`pattern` except

--- a/src/values.rst
+++ b/src/values.rst
@@ -226,10 +226,7 @@ The following :t:`[construct]s` are :t:`[variable]s`:
   A :t:`temporary`.
 
 * :dp:`fls_81dlbula47nu`
-  A named :t:`binding`.
-
-* :dp:`fls_adqfhc5k051x`
-  A named :t:`function parameter`.
+  A :t:`binding`.
 
 :dp:`fls_r9km9f969bu8`
 A :t:`variable` shall be used only after it has been initialized through all


### PR DESCRIPTION
We currently define them by using each other, which is obviously a bad definition.