### PR TITLE
Configure Dependabot to keep the shared submodule up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This should hopefully configure Dependabot to update the `shared/` submodule automatically :crossed_fingers: 