### PR TITLE
Define unsafety without mentioning memory-safety guarantees

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -7304,8 +7304,9 @@ unsafe operation
 ^^^^^^^^^^^^^^^^
 
 :dp:`fls_34h60ubicgsj`
-An :dt:`unsafe operation` is an operation that can potentially violate the
-memory-safety guarantees of Rust.
+An :dt:`unsafe operation` is an operation that may result in
+:t:`undefined behavior` that is not diagnosed as a static error.
+:t:`[Unsafe operation]s` are referred to as :t:`unsafe Rust`.
 
 .. _fls_4f6mppoenj3b:
 

--- a/src/unsafety.rst
+++ b/src/unsafety.rst
@@ -14,9 +14,9 @@ Unsafety
 :t:`Unsafety` is the presence of :t:`[unsafe operation]s` in program text.
 
 :dp:`fls_ovn9czwnwxue`
-An :t:`unsafe operation` is an operation that can potentially violate the
-memory-safety guarantees of Rust. :t:`[Unsafe operation]s` are referred to as
-:t:`unsafe Rust`.
+An :t:`unsafe operation` is an operation that may result in
+:t:`undefined behavior` that is not diagnosed as a static error.
+:t:`[Unsafe operation]s` are referred to as :t:`unsafe Rust`.
 
 :dp:`fls_pfhmcafsjyf7`
 The :t:`[unsafe operation]s` are:


### PR DESCRIPTION
Fixes https://github.com/ferrocene/specification/issues/158

All UB in Rust is ruled out statically, with the exception of UB caused by unsafe operations. Let's define them according to that.