### PR TITLE
Remove the caution notice from the FLS

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -36,9 +36,6 @@ templates_path = []
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-rst_prolog = """
-"""
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -37,11 +37,6 @@ templates_path = []
 exclude_patterns = []
 
 rst_prolog = """
-.. caution::
-
-   You're reading a draft of the Ferrocene Language Specification. Some parts
-   of this document might be missing, incomplete or incorrect. Our aim is to
-   have the specification ready by the end of 2022.
 """
 
 


### PR DESCRIPTION
The caution notice is no longer needed. The FLS already reflects 1.68.