### PR TITLE
Clarify that `UnicodeEscape` doesn't include surrogates and noncharacters

### DIFF
--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1010,6 +1010,10 @@ A :ds:`CharacterLiteralCharacter` is any :t:`Unicode` character except
 characters 0x09 (horizontal tabulation), 0x0A (new line), 0x0D (carriage
 return), 0x27 (apostrophe), and 0x5c (reverse solidus).
 
+A :ds:`UnicodeEscape` is any :t:`Unicode` codepoint between U+00000
+and U+10FFFF, except Unicode surrogate codepoints, which exist between
+the range of U+D800 and U+DFFF, inclusive.
+
 .. rubric:: Legality Rules
 
 :dp:`fls_vag2oy4q7d4n`

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1002,18 +1002,17 @@ Character Literals
      | $$\\$$
      | $$\x$$ OctalDigit HexadecimalDigit
 
-   UnicodeEscape ::=
-       $$\u{$$ (HexadecimalDigit $$_$$*)1-6 $$}$$
-
 :dp:`fls_j9q9ton57rvl`
 A :ds:`CharacterLiteralCharacter` is any :t:`Unicode` character except
 characters 0x09 (horizontal tabulation), 0x0A (new line), 0x0D (carriage
 return), 0x27 (apostrophe), and 0x5c (reverse solidus).
 
 :dp:`fls_5v9gx22g5wPm`
-A :ds:`UnicodeEscape` is any :t:`Unicode` codepoint between U+00000
-and U+10FFFF, inclusive, except Unicode surrogate codepoints, which exist
-between the range of U+D800 and U+DFFF, inclusive.
+A :ds:`UnicodeEscape` starts with a ``\u{`` character, followed by 1 to 6
+instances of a :s:`HexadecimalDigit`, inclusive, followed by a ``}`` character.
+It can represent any :t:`Unicode` codepoint between U+00000 and U+10FFFF,
+inclusive, except :t:`Unicode` surrogate codepoints, which exist between
+the range of U+D800 and U+DFFF, inclusive.
 
 .. rubric:: Legality Rules
 

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1008,7 +1008,7 @@ characters 0x09 (horizontal tabulation), 0x0A (new line), 0x0D (carriage
 return), 0x27 (apostrophe), and 0x5c (reverse solidus).
 
 :dp:`fls_5v9gx22g5wPm`
-A :ds:`UnicodeEscape` starts with a ``\u{`` character, followed by 1 to 6
+A :ds:`UnicodeEscape` starts with a ``\u{`` literal, followed by 1 to 6
 instances of a :s:`HexadecimalDigit`, inclusive, followed by a ``}`` character.
 It can represent any :t:`Unicode` codepoint between U+00000 and U+10FFFF,
 inclusive, except :t:`Unicode` surrogate codepoints, which exist between

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1010,9 +1010,10 @@ A :ds:`CharacterLiteralCharacter` is any :t:`Unicode` character except
 characters 0x09 (horizontal tabulation), 0x0A (new line), 0x0D (carriage
 return), 0x27 (apostrophe), and 0x5c (reverse solidus).
 
+:dp:`fls_5v9gx22g5wPm`
 A :ds:`UnicodeEscape` is any :t:`Unicode` codepoint between U+00000
-and U+10FFFF, except Unicode surrogate codepoints, which exist between
-the range of U+D800 and U+DFFF, inclusive.
+and U+10FFFF, inclusive, except Unicode surrogate codepoints, which exist
+between the range of U+D800 and U+DFFF, inclusive.
 
 .. rubric:: Legality Rules
 


### PR DESCRIPTION
Fixes #407 