### PR TITLE
Remove term `primitive type`

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -2503,7 +2503,7 @@ of the :t:`modifying operand` is the :t:`trait implementation`
 The :t:`evaluation` of a :t:`compound assignment` proceeds as follows:
 
 #. :dp:`fls_4nnqz4etisgw`
-   If the :t:`[type]s` of both :t:`[operand]s` are :t:`[primitive type]s`, then
+   If the :t:`[type]s` of both :t:`[operand]s` are :t:`[integer type]s` or :t:`[floating-point type]s`, then
 
    #. :dp:`fls_a2g4hs15jpiu`
       The :t:`modifying operand` is evaluated.

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -901,8 +901,8 @@ borrowed
 ^^^^^^^^
 
 :dp:`fls_3gnps2s95ck4`
-A memory location is :dt:`borrowed` when it acts as the :t:`operand` of a
-:t:`borrow expression`. **This explanation is not good enough.**
+A memory location is :dt:`borrowed` when a :t:`reference` pointing to it is
+:t:`active`.
 
 .. _fls_95c5cbc2jvpc:
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -5003,20 +5003,6 @@ primitive representation
 :dt:`Primitive representation` is the :t:`type representation` of
 :t:`[integer type]s`.
 
-.. _fls_iiww3jogl3x0:
-
-primitive type
-^^^^^^^^^^^^^^
-
-:dp:`fls_xu454ni4ls4k`
-A :dt:`primitive type` is a :t:`type` class that includes the :t:`never type`,
-:t:`[scalar type]s`, and type :c:`str`.
-
-:dp:`fls_cn82v86wr8z0`
-**Setting as a reminder, we'll have to check the usages of primitive types.
-It might be that the reference (where I assume we copied some usages from) was
-referring to a broader set of types as primitives.**
-
 .. _fls_v1u1mevpj0kj:
 
 private visibility

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1509,7 +1509,7 @@ is tool-defined.
 
 :dp:`fls_u1zy06510m56`
 The :t:`discriminant type` of an :t:`enum type` with
-:t:`primitive representation` is the :t:`primitive type` specified by the
+:t:`primitive representation` is the :t:`integer type` specified by the
 :t:`primitive representation`.
 
 :dp:`fls_ryvqkcx48u74`
@@ -2180,7 +2180,7 @@ depending on the :t:`type inference root` as follows:
   * :dp:`fls_vYvumjTQH9Xg`
     If the :t:`enum type` that contains the :t:`discriminant` is subject to
     :t:`attribute` :c:`repr` that specifies a :t:`primitive representation`, the
-    :t:`expected type` is the specified :t:`primitive type`.
+    :t:`expected type` is the specified :t:`integer type`.
 
   * :dp:`fls_QaGKt99CmvF6`
     Otherwise, the :t:`expected type` is :c:`isize`.


### PR DESCRIPTION
The term serves no purpose and was incorrectly used before