### PR TITLE
Synchronize with the monorepo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 ====================================================
 Contributing to the Ferrocene Language Specification

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 ================================
 Ferrocene Language Specification
@@ -11,11 +11,10 @@ Ferrocene Language Specification
    specification &raquo;</a></p>
 
 The Ferrocene Language Specification (FLS) is a document describing the Rust
-language. It was created by a joint effort between `Ferrous Systems`_ and
-`AdaCore`_ as one of the prerequisites for qualifying `Ferrocene`_, a Rust
-toolchain qualified for safety-critical environments. The FLS is compiled of
-existing Rust documentation, but presented with a rigorous structure in order
-to meet the requirements of qualification.
+language. It was created as one of the prerequisites for qualifying
+`Ferrocene`_, a Rust toolchain qualified for safety-critical environments. The
+FLS is compiled of existing Rust documentation, but presented with a rigorous
+structure in order to meet the requirements of qualification.
 
 The FLS is not intended to be used as the normative specification of the Rust
 language nor is it's meant to replace the decision-making processes of the Rust
@@ -27,8 +26,6 @@ or ``Apache-2.0`` licenses, at your option. Individual files might have
 different licensing. Licensing metadata is present in each file, and the full
 licenses text is present in the ``LICENSES/`` directory.
 
-.. _Ferrous Systems: https://ferrous-systems.com
-.. _AdaCore: https://adacore.com
 .. _Ferrocene: https://ferrocene.dev
 
 Building the specification

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 # Gate PRs on the GitHub Actions job "CI"
 status = ["CI"]

--- a/exts/ferrocene_spec/README.rst
+++ b/exts/ferrocene_spec/README.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 ====================
 FLS Sphinx Extension

--- a/exts/ferrocene_spec/__init__.py
+++ b/exts/ferrocene_spec/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from . import definitions, informational, syntax_directive, std_role, paragraph_ids
 from . import items_with_rubric

--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from . import paragraphs, syntax, terms, code_terms
 from docutils import nodes

--- a/exts/ferrocene_spec/definitions/code_terms.py
+++ b/exts/ferrocene_spec/definitions/code_terms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec/definitions/paragraphs.py
+++ b/exts/ferrocene_spec/definitions/paragraphs.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from .. import utils
 from collections import defaultdict

--- a/exts/ferrocene_spec/definitions/syntax.py
+++ b/exts/ferrocene_spec/definitions/syntax.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec/definitions/terms.py
+++ b/exts/ferrocene_spec/definitions/terms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec/informational.py
+++ b/exts/ferrocene_spec/informational.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from . import utils
 from collections import defaultdict

--- a/exts/ferrocene_spec/items_with_rubric.py
+++ b/exts/ferrocene_spec/items_with_rubric.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from collections import defaultdict
 from dataclasses import dataclass

--- a/exts/ferrocene_spec/paragraph_ids.py
+++ b/exts/ferrocene_spec/paragraph_ids.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from . import definitions, informational, utils
 from collections import defaultdict

--- a/exts/ferrocene_spec/std_role.py
+++ b/exts/ferrocene_spec/std_role.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from docutils import nodes
 from sphinx.roles import SphinxRole

--- a/exts/ferrocene_spec/syntax_directive.py
+++ b/exts/ferrocene_spec/syntax_directive.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from .definitions import DefIdNode, DefRefNode
 from docutils import nodes

--- a/exts/ferrocene_spec/utils.py
+++ b/exts/ferrocene_spec/utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from docutils import nodes
 

--- a/exts/ferrocene_spec_lints/__init__.py
+++ b/exts/ferrocene_spec_lints/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 import sphinx
 import typing

--- a/exts/ferrocene_spec_lints/alphabetical_section_titles.py
+++ b/exts/ferrocene_spec_lints/alphabetical_section_titles.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 import re
 from docutils import nodes

--- a/exts/ferrocene_spec_lints/require_paragraph_ids.py
+++ b/exts/ferrocene_spec_lints/require_paragraph_ids.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 from docutils import nodes
 from ferrocene_spec.definitions import DefIdNode

--- a/generate-random-ids.py
+++ b/generate-random-ids.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 # Convenience script to generate a list of random paragraph IDs, ready to be
 # copy-pasted as you write new paragraphs.

--- a/make.py
+++ b/make.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 import os
 import subprocess

--- a/src/associated-items.rst
+++ b/src/associated-items.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/concurrency.rst
+++ b/src/concurrency.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -1,20 +1,20 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
-# SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+# SPDX-FileCopyrightText: The Ferrocene Developers
 
 # -- Path setup --------------------------------------------------------------
 
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../exts"))
-sys.path.insert(1, os.path.abspath("../shared/exts"))
+sys.path.append(os.path.abspath("../exts"))
+sys.path.append(os.path.abspath("../shared/exts"))
 
 
 # -- Project information -----------------------------------------------------
 
 project = "Ferrocene Language Specification"
-copyright = "Ferrous Systems and AdaCore"
-author = "Ferrous Systems and AdaCore"
+copyright = "The Ferrocene Developers"
+author = "The Ferrocene Developers"
 
 
 # -- General configuration ---------------------------------------------------
@@ -35,7 +35,6 @@ templates_path = []
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/exceptions-and-errors.rst
+++ b/src/exceptions-and-errors.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/ffi.rst
+++ b/src/ffi.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/functions.rst
+++ b/src/functions.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/general.rst
+++ b/src/general.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/generics.rst
+++ b/src/generics.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/implementations.rst
+++ b/src/implementations.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/index.rst
+++ b/src/index.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 Ferrocene Language Specification
 ================================

--- a/src/inline-assembly.rst
+++ b/src/inline-assembly.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/items.rst
+++ b/src/items.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/licenses.rst
+++ b/src/licenses.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/macros.rst
+++ b/src/macros.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/ownership-and-deconstruction.rst
+++ b/src/ownership-and-deconstruction.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/program-structure-and-compilation.rst
+++ b/src/program-structure-and-compilation.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/statements.rst
+++ b/src/statements.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/undefined-behavior.rst
+++ b/src/undefined-behavior.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Critical Section GmbH
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 .. informational-page::

--- a/src/unsafety.rst
+++ b/src/unsafety.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 

--- a/src/values.rst
+++ b/src/values.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
-   SPDX-FileCopyrightText: Ferrous Systems and AdaCore
+   SPDX-FileCopyrightText: The Ferrocene Developers
 
 .. default-domain:: spec
 


### PR DESCRIPTION
This PR synchronizes the spec contents with the `ferrocene/ferrocene` monorepo.