### PR TITLE
Fix RubricCollector.clear_doc()

### DIFF
--- a/exts/ferrocene_spec/items_with_rubric.py
+++ b/exts/ferrocene_spec/items_with_rubric.py
@@ -40,11 +40,7 @@ class RubricCollector(EnvironmentCollector):
     def clear_doc(self, app, env, docname):
         storage = get_storage(env)
         for rubric, items in storage.items():
-            # This makes a copy of the list (with `list(items)`) to be able to
-            # remove items from it without affecting the iteration.
-            for i, item in enumerate(list(items)):
-                if item.document == docname:
-                    items.pop(i)
+            items[:] = (item for item in items if item.document != docname)
 
     def merge_other(self, app, env, docnames, other):
         current = get_storage(env)


### PR DESCRIPTION
I've seen occasional errors like the following on incremental builds:

````
Extension error (ferrocene_spec.items_with_rubric):
Handler <bound method RubricCollector.clear_doc of <ferrocene_spec.items_with_rubric.RubricCollector object at 0x7f4a44a47e50>> for event 'env-purge-doc' threw an exception (exception: pop index out of range)
````

The following code in `exts/ferrocene_spec/items_with_rubric.py`

````
    # This makes a copy of the list (with `list(items)`) to be able to
    # remove items from it without affecting the iteration.
    for i, item in enumerate(list(items)):
        if item.document == docname:
            items.pop(i)
````

won't work as intended if it finds more than one item to remove, because the first `pop` will change the positions of the following elements of the list.


