### PR TITLE
Macro called in pattern-without-range expand to a _single_ pattern

### DIFF
--- a/src/macros.rst
+++ b/src/macros.rst
@@ -648,8 +648,8 @@ Macro Expansion
 
    #. :dp:`fls_tu6kmwm4v9nj`
       If the :t:`macro invocation` appears as part of a
-      :t:`pattern-without-range`, the output is required to constitute zero or
-      more :t:`[pattern]s`.
+      :t:`pattern-without-range`, the output is required to constitute a
+      :t:`[pattern]`.
 
    #. :dp:`fls_3zn4dz19nyvq`
       If the :t:`macro invocation` appears as part of a :t:`statement`, the


### PR DESCRIPTION
The current specification says that a macro called in pattern context can expand to zero or more patterns.

I believe this is incorrect, as e.g. `0 1 _` is effectively 0 or more patterns, but is not a valid expansion ([playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=86464c2a830b8d5550cd7947275d7dee)). Similarly, expanding to 0 patterns is invalid ([playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=f56438b84bed3893105ba138af8913a6)).

As I understand it, the intent was to state that e.g. `0 | 1 | _` is a valid expansion for a pattern called in pattern context. As such, I changed the wording so that macro calls in pattern context must expand to a pattern, which matches `0 | 1 | _` and makes "expanding to zero patterns" invalid.