### PR TITLE
remove empty field list in unions

### DIFF
--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -800,8 +800,10 @@ Union Types
 .. syntax::
 
    UnionDeclaration ::=
-       $$union$$ Name GenericParameterList? WhereClause? RecordStructFieldList
+       $$union$$ Name GenericParameterList? WhereClause? UnionFieldList
 
+   UnionFieldList ::=
+       $${$$ RecordStructField ($$,$$ RecordStructField)* $$,$$? $$}$$
 .. rubric:: Legality Rules
 
 :dp:`fls_nskmnzq95yqm`

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -800,15 +800,17 @@ Union Types
 .. syntax::
 
    UnionDeclaration ::=
-       $$union$$ Name GenericParameterList? WhereClause? UnionFieldList
+       $$union$$ Name GenericParameterList? WhereClause? RecordStructFieldList
 
-   UnionFieldList ::=
-       $${$$ RecordStructField ($$,$$ RecordStructField)* $$,$$? $$}$$
 .. rubric:: Legality Rules
 
 :dp:`fls_nskmnzq95yqm`
 A :t:`union type` is an :t:`abstract data type` that is a sum of other
 :t:`types`.
+
+:dp:`fls_nskmnzq95yqn`
+A :t:`union` without any :t:`[union field]s` is rejected, but may still be consumed by
+:t:`[macro]s`.
 
 :dp:`fls_1caus8ybmfli`
 The :t:`name` of a :t:`union field` shall be unique within the related

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -808,7 +808,7 @@ Union Types
 A :t:`union type` is an :t:`abstract data type` that is a sum of other
 :t:`types`.
 
-:dp:`fls_nskmnzq95yqn`
+:dp:`fls_I5fN5Fmo5CyK`
 A :t:`union` without any :t:`[union field]s` is rejected, but may still be consumed by
 :t:`[macro]s`.
 


### PR DESCRIPTION
Rust unions cannot have zero fields, in contrast to enums and structs. (https://github.com/ferrocene/ferrocene/blob/main/tests/ui/union/union-empty.rs)