### PR TITLE
Fix typos

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -2853,7 +2853,7 @@ Indexing Expressions
 .. rubric:: Legality Rules
 
 :dp:`fls_X9kdEAPTqsAe`
-A :t:`indexable type` is a :t:`type` that implements the
+An :t:`indexable type` is a :t:`type` that implements the
 :std:`core::ops::Index` :t:`trait`.
 
 :dp:`fls_42ijvuqqqlvh`
@@ -3815,7 +3815,7 @@ An :t:`infinite loop expression` is a :t:`loop expression` that continues to
 evaluate its :t:`loop body` indefinitely.
 
 :dp:`fls_b314wjbv0zwe`
-The :t:`type` of a :t:`infinite loop expression` is determined as follows:
+The :t:`type` of an :t:`infinite loop expression` is determined as follows:
 
 * :dp:`fls_rpedapxnv8w3`
   If the :t:`infinite loop expression` does not contain a :t:`break expression`,
@@ -3827,7 +3827,7 @@ The :t:`type` of a :t:`infinite loop expression` is determined as follows:
   :t:`[break type]s` of all :t:`[break expression]s`.
 
 :dp:`fls_q3qpcf2fz7h`
-The :t:`value` of a :t:`infinite loop expression` is determined as follows:
+The :t:`value` of an :t:`infinite loop expression` is determined as follows:
 
 * :dp:`fls_2ulbzmuuny3g`
   If the :t:`infinite loop expression` does not contain a :t:`break expression`,

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -3747,10 +3747,10 @@ The :t:`type` of a :t:`subject expression` shall implement the
 The :t:`expected type` of the :t:`pattern` is the :t:`associated type` :std:`core::iter::IntoIterator::Item` of the :t:`subject expression`'s :std:`core::iter::IntoIterator` implementation.
 
 :dp:`fls_bmTjhKdpfgCB`
-The :t:`type` of an :t:`for loop expression` is the :t:`unit type`.
+The :t:`type` of a :t:`for loop expression` is the :t:`unit type`.
 
 :dp:`fls_FkxLf91WKiIo`
-The :t:`value` of an :t:`for loop expression` is the :t:`unit value`.
+The :t:`value` of a :t:`for loop expression` is the :t:`unit value`.
 
 .. rubric:: Dynamic Semantics
 
@@ -3887,10 +3887,10 @@ of a :t:`while loop expression`.
 The :t:`type` of an :t:`iteration expression` shall be :t:`type` :c:`bool`.
 
 :dp:`fls_P8iyTN6KZCVA`
-The :t:`type` of an :t:`while loop expression` is the :t:`unit type`.
+The :t:`type` of a :t:`while loop expression` is the :t:`unit type`.
 
 :dp:`fls_s6hRa5spz64w`
-The :t:`value` of an :t:`while loop expression` is the :t:`unit value`.
+The :t:`value` of a :t:`while loop expression` is the :t:`unit value`.
 
 .. rubric:: Dynamic Semantics
 
@@ -3943,10 +3943,10 @@ a :t:`value` that can be matched against its :t:`pattern`.
 The :t:`expected type` of the :t:`pattern` is the :t:`type` of the :t:`subject let expression`.
 
 :dp:`fls_gTfSLePwHTES`
-The :t:`type` of an :t:`while let loop expression` is the :t:`unit type`.
+The :t:`type` of a :t:`while let loop expression` is the :t:`unit type`.
 
 :dp:`fls_pTq4LIGIoAtN`
-The :t:`value` of an :t:`while let loop expression` is the :t:`unit value`.
+The :t:`value` of a :t:`while let loop expression` is the :t:`unit value`.
 
 .. rubric:: Dynamic Semantics
 

--- a/src/ffi.rst
+++ b/src/ffi.rst
@@ -159,7 +159,7 @@ An :t:`external block` is a :t:`construct` that provides the declarations of
 foreign :t:`[function]s` as unchecked imports.
 
 :dp:`fls_Nz0l16hMxqTd`
-The :t:`ABI` of a :t:`extern block` is determined as follows:
+The :t:`ABI` of an :t:`extern block` is determined as follows:
 
 * :dp:`fls_4XOoiFloXM7t`
   If the :t:`extern block` specifies an :s:`AbiKind`, then the :t:`ABI` is the specified :s:`AbiKind`.

--- a/src/program-structure-and-compilation.rst
+++ b/src/program-structure-and-compilation.rst
@@ -73,7 +73,7 @@ Modules
 A :t:`module` is a container for zero or more :t:`[item]s`.
 
 :dp:`fls_whgv72emrm47`
-The ``unsafe`` :t:`keyword` of an :t:`module` is rejected, but may still
+The ``unsafe`` :t:`keyword` of a :t:`module` is rejected, but may still
 be consumed by :t:`[macro]s`.
 
 :dp:`fls_qypjjpcf8uwq`

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1738,11 +1738,11 @@ proceeds as follows:
       Otherwise, :t:`type unification` fails.
 
 #. :dp:`fls_Hb95CPyUpCmc`
-   Otherwise, if one :t:`type` ``T`` is an :t:`floating-point type variable`,
+   Otherwise, if one :t:`type` ``T`` is a :t:`floating-point type variable`,
    behavior depends on the other :t:`type` ``U``:
 
    #. :dp:`fls_jEZVWlfVPevb`
-      If ``U`` is an :t:`floating-point type` or an
+      If ``U`` is a :t:`floating-point type` or an
       :t:`floating-point type variable`, the :t:`floating-point type variable`
       ``T`` is assigned :t:`type` ``U``.
 
@@ -3019,7 +3019,7 @@ A :t:`trait` is :t:`invariant` in all inputs, including the :c:`Self` parameter.
 
 :dp:`fls_abn5ycx11zpm`
 The :t:`variance` of a :t:`generic parameter` of an :t:`abstract data type` or
-an :t:`tuple type` is determined as follows:
+a :t:`tuple type` is determined as follows:
 
 #. :dp:`fls_hvfyog9ygn6q`
    For each :t:`generic parameter` ``G``:


### PR DESCRIPTION
use "a" before consonant sound and "an" before vowel sound