### PR TITLE
add while loop syntax fix

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -3870,7 +3870,7 @@ While Loops
        $$while$$ IterationExpression LoopBody
 
    IterationExpression ::=
-       Expression
+       SubjectExpression
 
 .. rubric:: Legality Rules
 


### PR DESCRIPTION
According to the Rust Reference, "while loop expressions", as well as "if expressions" should accept any expression except struct expressions (SubjectExpression). So, this must be more accurate.