### PR TITLE
explain union behavior in writing

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -3550,6 +3550,10 @@ field`'s type.
 The :t:`evaluation` of a :t:`field access expression` evaluates its
 :t:`container operand`.
 
+:dp:`fls_OuEX9IcrEfaW`
+Because all fields of a :t:`union` share the same storage, writing
+to one field of a :t:`union`` will overwrite the contents of its other fields.
+
 .. rubric:: Examples
 
 :dp:`fls_x27yayh4z787`


### PR DESCRIPTION
I think it is important to explain this behavior of unions, that when writing to one field, the others are overwritten. I couldn't see it mentioned somewhere.