### PR TITLE
Fix array repetition operand evaluation

### DIFF
--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -2864,17 +2864,10 @@ The :t:`evaluation` of an :t:`array expression` with an
 :t:`array repetition constructor` proceeds as follows:
 
 #. :dp:`fls_f3izbkm8607z`
-   If the :t:`value` of the :t:`size operand` is greater than zero, then:
-
-   #. :dp:`fls_qbyysx30pjzs`
-      If the :t:`repeat operand` denotes a :t:`constant`, the
-      :t:`repeat operand` is evaluated once and its :t:`value` is
-      :t:`passed <passing convention>` :t:`by copy` :t:`[size operand]'s`
-      :t:`value` times.
-
-   #. :dp:`fls_1m0laldldh7j`
-      Otherwise the :t:`repeat operand` is evaluated :t:`[size operand]'s`
-      :t:`value` times.
+   If the :t:`value` of the :t:`size operand` is greater than zero, then the
+   :t:`repeat operand` is evaluated once and its :t:`value` is
+   :t:`passed <passing convention>` :t:`by copy` :t:`[size operand]'s`
+   :t:`value` times.
 
 #. :dp:`fls_5cs68nm54l31`
    Otherwise the :t:`repeat operand` is evaluated once.


### PR DESCRIPTION
It turns out that `[<repeated>; <length>]` evaluates `<repeated>` only one time, as seen in the following example:

```rust
fn main() {
    let mut counter = 0;
    [{
        counter += 1;
    }; 9];
    assert_eq!(counter, 1);
}
```

###### [Playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b7ca3de9ba64675238380acae97fde37)

This PR updates the doc in order to match this behavior.