### PR TITLE
we have since stopped using setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    # Ubuntu 22.04 does not support actions/setup-python with Python 3.6 as of
-    # 2022-11-24. See https://github.com/actions/setup-python/issues/544.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Also, ubuntu-20.04 runner is deprecated