### PR TITLE
Claim to follow Unicode 16 for lexing identifiers.

### DIFF
--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -476,7 +476,7 @@ keyword]s`.
 
 :dp:`fls_jpecw46eh061`
 A :t:`pure identifier` shall follow the specification in Unicode Standard Annex
-#31 for :t:`Unicode` version 13.0, with the following profile:
+#31 for :t:`Unicode` version 16.0, with the following profile:
 
 * :dp:`fls_lwcflgezgs5z`
   ``Start`` = ``XID_Start``, plus character 0x5F (low line).


### PR DESCRIPTION
Rustc has used Unicode 16 since Rust 1.83.

This change brings the FLS into sync with the Reference for this detail.
See rust-lang/reference#1688.

I'm not sure whether the changelog should be updated (and if so, how). The FLS was previously claiming Unicode version 13. I don't have notes saying which versions the updates to Unicode 14 and 15 happened in.

Unicode normalization is also dependent on the Unicode version, but there's no version number in the existing text of §2.3:16 (`fls_vde7gev5rz4q`).
