### PR TITLE
fix freestanding `let` in a module and wrong brackets

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -62,8 +62,8 @@ an :t:`attribute`.
 
 .. code-block:: rust
 
-   #[cfg[target_os = "linux"]]
-   mod linux_only_module {
+   #[cfg(target_os = "linux")]
+   fn linux_only_function() {
        #![allow(unused_variables)]
 
        let unused = ();


### PR DESCRIPTION
Modules cannot have a free-standing `let foo = ..`, so either the module needs to be changed into a function, or a `let` needs to be changed into a `static`/`const`. This PR goes with the former.

In addition, the `cfg` attribute uses incorrect brackets: `cfg[]` instead of `cfg()`.