### PR TITLE
fix order, and delimiting and trailing comma for `repr` attribute

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -1499,10 +1499,14 @@ Attribute ``repr``
 .. syntax::
 
    ReprContent ::=
-       $$repr$$ $$($$ Representation $$)$$
+       $$repr$$ $$($$ RepresentationList $$)$$
+
+   RepresentationList ::=
+       Representation ($$,$$ Representation)* $$,$$?
 
    Representation ::=
-       RepresentationKind Alignment?
+       RepresentationKind
+     | Alignment
 
    RepresentationKind ::=
        PrimitiveRepresentation


### PR DESCRIPTION
The `repr()` attribute allows definitions to be specified in any order:

    #[repr(C, align(64))]
    struct Foo(i32);

    #[repr(align(64), C)]
    struct Bar(i32);

They can also only have `Alignment` present:

    #[repr(align(64))]
    struct Baz(i32);

And a trailing comma:

    #[repr(packed,)]
    struct Qux(i32);

In addition, previous version of the `Representation` category did not require a delimiting comma (`repr(C packed)`).

To fix these issues, introduce a list of representations.