### PR TITLE
glossary: Unicode: refer to the Consortium's one, not ISO/IEC's

### DIFF
--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -7259,8 +7259,9 @@ Unicode
 ^^^^^^^
 
 :dp:`fls_y7gwku7pe1f4`
-:dt:`Unicode` is the colloquial name for the ISO/IEC 10646:2017 Universal Coded
-Character Set standard.
+:dt:`Unicode` is the universal character encoding standard for written
+characters and text described in the Unicode® Standard by the Unicode
+Consortium.
 
 .. _fls_y7m6AentM6Ik:
 


### PR DESCRIPTION
The Unicode Standard and ISO/IEC 10646 are different standards [1].

Since `fls_jpecw46eh061` refers to a Unicode Standard version, change the glossary entry to point to the Consortium's standard instead.

This may also make it easier to refer to future versions since there may be no published ISO/IEC standard for that version, at least for some time.

The description between "is" and "described" is taken from Chapter 1 ("Introduction") of the Core Specification.

The version is not specified since it is already noted elsewhere (and, in principle, it could be possible that different parts refer to different versions -- if that is not desirable, it may make sense to move the version here instead, like for the C standard one).

Fixes: https://github.com/rust-lang/fls/issues/155
Fixes: https://github.com/rust-lang/fls/issues/156
Link: https://www.unicode.org/faq/unicode_iso [1]