### PR TITLE
adjust for downstream branch name change

### DIFF
--- a/make.py
+++ b/make.py
@@ -87,8 +87,8 @@ def build_linkchecker(root):
             f.write("/src/tools/linkchecker/")
 
         # Avoid fetching the whole history
-        git(["fetch", "--depth=1", "origin", "master"])
-        git(["checkout", "master"])
+        git(["fetch", "--depth=1", "origin", "main"])
+        git(["checkout", "main"])
 
     if not bin.is_file():
         subprocess.run(["cargo", "build", "--release"], cwd=src, check=True)


### PR DESCRIPTION
Else we get [a CI fail](https://github.com/rust-lang/fls/actions/runs/19236342323/job/54987184786)
```
fatal: couldn't find remote ref master
Traceback (most recent call last):
  File "/home/runner/work/fls/fls/./make.py", line 158, in <module>
    main(os.path.abspath(os.path.dirname(__file__)))
  File "/home/runner/work/fls/fls/./make.py", line 152, in main
    linkchecker = build_linkchecker(root)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/fls/fls/./make.py", line 90, in build_linkchecker
    git(["fetch", "--depth=1", "origin", "master"])
  File "/home/runner/work/fls/fls/./make.py", line 77, in git
    subprocess.run(["git", *args], cwd=repo, check=True)
  File "/usr/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'fetch', '--depth=1', 'origin', 'master']' returned non-zero exit status 128.
