### PR TITLE
[Change]: [1.91.0, 1.91.1] Stabilize 'sse4a' and 'tbm' target features

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -522,7 +522,9 @@ Attribute ``target_feature``
      | $$sse3$$
      | $$sse4.1$$
      | $$sse4.2$$
+     | $$sse4a$$
      | $$ssse3$$
+     | $$tbm$$
      | $$vaes$$
      | $$vpclmulqdq$$
      | $$widekl$$
@@ -723,10 +725,18 @@ The target architecture features are as follows:
      - sse4.2.
      - sse4.1
      - Streaming SIMD Extensions 4.2
+   * - :dp:`fls_pGHKFrgGlFtg`
+     - sse4a
+     - sse3
+     - Streaming SIMD Extensions 4a
    * - :dp:`fls_9x2on8w44k4f`
      - ssse3
      - sse3
      - Supplemental Streaming SIMD Extensions 3
+   * - :dp:`fls_K6TM6oTLL1BA`
+     - tbm
+     -
+     - Trailing Bit Manipulation
    * - :dp:`fls_gRf8F9PIGySt`
      - vaes
      - avx2, aes

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -49,6 +49,14 @@ Language changes in Rust 1.91.0
 
 - `Stabilize 'sse4a' and 'tbm' target features <https://github.com/rust-lang/rust/pull/144542>`_
 
+  - Changed syntax: :s:`Feature`
+
+  * New paragraphs:
+
+    - :p:`fls_pGHKFrgGlFtg`
+
+    - :p:`fls_K6TM6oTLL1BA`
+
 - `Add 'target_env = "macabi"' and 'target_env = "sim"' cfgs <https://github.com/rust-lang/rust/pull/139451>`_ as replacements for the `target_abi` cfgs with the same values.
 
 Language changes in Rust 1.90.0


### PR DESCRIPTION
This PR modifies the FLS to reflect the stabilization of the `sse4a` and `tbm` features of the `target_feature` attribute.

Issue: https://github.com/rust-lang/fls/issues/625