### PR TITLE
[Change]: [1.91.0, 1.91.1] Add 'target_env = "macabi"' and "sim"

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -59,6 +59,8 @@ Language changes in Rust 1.91.0
 
 - `Add 'target_env = "macabi"' and 'target_env = "sim"' cfgs <https://github.com/rust-lang/rust/pull/139451>`_ as replacements for the `target_abi` cfgs with the same values.
 
+  - No change: configuration options are environment-specific and not exhaustive
+
 Language changes in Rust 1.90.0
 -------------------------------
 


### PR DESCRIPTION
This PR updates the FLS changelog to indicate that this 1.91.0 language change is not relevant to the FLS.

Issue: https://github.com/rust-lang/fls/issues/626