### PR TITLE
Fix various small issues

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -176,6 +176,9 @@ The following :t:`[built-in attribute]s` are :dt:`[code generation attribute]s`:
 * :dp:`fls_tvn08dtuilue`
   :t:`Attribute` :c:`inline`.
 
+* :dp:`fls_eOJS3mxa9xgu`
+  :t:`Attribute` :c:`naked`.
+
 * :dp:`fls_q4c023zdsfgn`
   :t:`Attribute` :c:`no_builtins`.
 
@@ -184,9 +187,6 @@ The following :t:`[built-in attribute]s` are :dt:`[code generation attribute]s`:
 
 * :dp:`fls_gxxbf6eag3et`
   :t:`Attribute` :c:`track_caller`.
-
-* :dp:`fls_eOJS3mxa9xgu`
-  :t:`Attribute` :c:`naked`.
 
 :dp:`fls_87o6n9et9jio`
 The following :t:`[built-in attribute]s` are
@@ -219,20 +219,20 @@ The following :t:`[built-in attribute]s` are :dt:`[diagnostics attribute]s`:
 * :dp:`fls_s5z2q5pl14p4`
   :t:`Attribute` ``deprecated``.
 
+* :dp:`fls_NrTL2FruARAv`
+  :t:`Attribute` ``expect``.
+
 * :dp:`fls_5ko0q9jnxv5a`
   :t:`Attribute` ``forbid``.
 
 * :dp:`fls_rgjf5ibhurda`
   :t:`Attribute` ``must_use``.
 
-* :dp:`fls_29y8icoou1gx`
-  :t:`Attribute` ``warn``.
-
-* :dp:`fls_NrTL2FruARAv`
-  :t:`Attribute` ``expect``.
-
 * :dp:`fls_4d2ArC50kNWL`
   :t:`Attribute` ``unsafe``.
+
+* :dp:`fls_29y8icoou1gx`
+  :t:`Attribute` ``warn``.
 
 :dp:`fls_3fxhz0olhbcy`
 The following :t:`[built-in attribute]s` are :dt:`[documentation attribute]s`:

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -1001,6 +1001,65 @@ Mutable borrow.
 
    let ref_answer = &mut answer;
 
+.. _fls_vXGuvRWOLbEE:
+
+Raw Borrow Expression
+~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: Syntax
+
+.. syntax::
+
+   RawBorrowExpression ::=
+       $$&$$ $$raw$$ ($$const$$ | $$mut$$) Operand
+
+.. rubric:: Legality Rules
+
+:dp:`fls_TS6DvMon5h27`
+A :t:`raw borrow expression` is an :t:`expression` that creates a :t:`raw pointer` to the memory location of its :t:`operand` without incurring a :t:`borrow`.
+
+:dp:`fls_UtjWrE2qeplQ`
+An :dt:`immutable raw borrow expression` is a :t:`raw borrow expression` that has :t:`keyword` ``const``.
+
+:dp:`fls_4e7EE4a8Yvmy`
+A :dt:`mutable raw borrow expression` is a :t:`raw borrow expression` that has :t:`keyword` ``mut``.
+
+:dp:`fls_gOXUWePymgGV`
+When the :t:`operand` of a :t:`raw borrow expression` is a :t:`place expression`, the :t:`raw borrow expression` produces a :t:`raw pointer` to the memory location indicated by the :t:`operand`.
+
+:dp:`fls_YBC8GrIBzZbi`
+It is a static error if the :t:`operand` of a :t:`raw borrow expression` is a :t:`temporary`.
+
+:dp:`fls_Twkre8IzUa8S`
+The :t:`type` of a :t:`raw borrow expression` is determined as follows:
+
+* :dp:`fls_Ki4FOzJMqtvJ`
+  If the :t:`raw borrow expression` denotes an :t:`immutable raw borrow expression`, then the :t:`type` is ``*const T``, where ``T`` is the :t:`type` of the :t:`operand`.
+
+* :dp:`fls_DJxQDBsO9hc7`
+  If the :t:`raw borrow expression` denotes a :t:`mutable raw borrow expression`, then the :t:`type` is ``*mut T``, where ``T`` is the :t:`type` of the :t:`operand`.
+
+:dp:`fls_WlXB0AHifCdd`
+The :t:`value` of a :t:`raw borrow expression` is the address of its :t:`operand`.
+
+.. rubric:: Dynamic Semantics
+
+:dp:`fls_qQrV8QuGGcVO`
+The :t:`evaluation` of a :t:`raw borrow expression` evaluates its :t:`operand`.
+
+.. rubric:: Examples
+
+.. code-block:: rust
+
+   let mut answer = 42;
+
+:dp:`fls_dTABiwAPGhdZ`
+Mutable raw borrow.
+
+.. syntax::
+
+   let ref_answer = &raw mut answer;
+
 .. _fls_5cm4gkt55hjh:
 
 Dereference Expression
@@ -2053,65 +2112,6 @@ The :t:`evaluation` of a :t:`lazy or expression` proceeds as follows:
 
    false && panic!()
    this || that
-
-.. _fls_vXGuvRWOLbEE:
-
-Raw Borrow Expression
-~~~~~~~~~~~~~~~~~~~~~
-
-.. rubric:: Syntax
-
-.. syntax::
-
-   RawBorrowExpression ::=
-       $$&$$ $$raw$$ ($$const$$ | $$mut$$) Operand
-
-.. rubric:: Legality Rules
-
-:dp:`fls_TS6DvMon5h27`
-A :t:`raw borrow expression` is an :t:`expression` that creates a :t:`raw pointer` to the memory location of its :t:`operand` without incurring a :t:`borrow`.
-
-:dp:`fls_UtjWrE2qeplQ`
-An :dt:`immutable raw borrow expression` is a :t:`raw borrow expression` that has :t:`keyword` ``const``.
-
-:dp:`fls_4e7EE4a8Yvmy`
-A :dt:`mutable raw borrow expression` is a :t:`raw borrow expression` that has :t:`keyword` ``mut``.
-
-:dp:`fls_gOXUWePymgGV`
-When the :t:`operand` of a :t:`raw borrow expression` is a :t:`place expression`, the :t:`raw borrow expression` produces a :t:`raw pointer` to the memory location indicated by the :t:`operand`.
-
-:dp:`fls_YBC8GrIBzZbi`
-It is a static error if the :t:`operand` of a :t:`raw borrow expression` is a :t:`temporary`.
-
-:dp:`fls_Twkre8IzUa8S`
-The :t:`type` of a :t:`raw borrow expression` is determined as follows:
-
-* :dp:`fls_Ki4FOzJMqtvJ`
-  If the :t:`raw borrow expression` denotes an :t:`immutable raw borrow expression`, then the :t:`type` is ``*const T``, where ``T`` is the :t:`type` of the :t:`operand`.
-
-* :dp:`fls_DJxQDBsO9hc7`
-  If the :t:`raw borrow expression` denotes a :t:`mutable raw borrow expression`, then the :t:`type` is ``*mut T``, where ``T`` is the :t:`type` of the :t:`operand`.
-
-:dp:`fls_WlXB0AHifCdd`
-The :t:`value` of a :t:`raw borrow expression` is the address of its :t:`operand`.
-
-.. rubric:: Dynamic Semantics
-
-:dp:`fls_qQrV8QuGGcVO`
-The :t:`evaluation` of a :t:`raw borrow expression` evaluates its :t:`operand`.
-
-.. rubric:: Examples
-
-.. code-block:: rust
-
-   let mut answer = 42;
-
-:dp:`fls_dTABiwAPGhdZ`
-Mutable raw borrow.
-
-.. syntax::
-
-   let ref_answer = &raw mut answer;
 
 .. _fls_1qhsun1vyarz:
 

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1384,7 +1384,7 @@ extend exactly one :t:`line`.
 :t:`[Inner block doc]s` and :t:`[inner line doc]s` are equivalent to
 :t:`attribute` :c:`doc` of the form ``#![doc = content]``, where ``content``
 is a :t:`string literal` form of the :t:`comment` without the leading ``//!``,
-``/*!`` amd trailing ``*/`` characters.
+``/*!`` and trailing ``*/`` characters.
 
 :dp:`fls_nWtKuPi8Fw6v`
 :t:`[Outer block doc]s` and :t:`[outer line doc]s` are equivalent to

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1125,8 +1125,8 @@ Impl Trait Types
        UseCapturesGenericArg ($$,$$ UseCapturesGenericArg)* $$,$$?
 
    UseCapturesGenericArg ::=
-       Lifetime
-     | Identifier
+       Identifier
+     | Lifetime
 
 .. rubric:: Legality Rules
 
@@ -1143,13 +1143,13 @@ An :t:`anonymous return type` is an :t:`impl trait type` ascribed to a
 :t:`function` :t:`return type`.
 
 :dp:`fls_Xo1ODwOyX7Vm`
-An :t:`anonymous return type` behaves as if it contained all declared :t:`[type
+An :t:`anonymous return type` behaves as if it contains all declared :t:`[type
 parameter]s` of the :t:`return type`'s :t:`function` and its parent :t:`trait`
 or :t:`implementation`.
 
 :dp:`fls_kTGFLFymTWch`
 An :t:`anonymous return type` derived from an :t:`async function` behaves as if
-it contained all declared :t:`[type parameter]s` and :t:`[lifetime parameter]s`
+it contains all declared :t:`[type parameter]s` and :t:`[lifetime parameter]s`
 of the :t:`return type`'s :t:`function` and its parent :t:`trait` or
 :t:`implementation`.
 
@@ -1163,7 +1163,7 @@ An :t:`use capture` is a :t:`generic parameter` referenced within an :t:`anonymo
 An :t:`anonymous return type` that does not specify a list of :t:`[use capture]s` implicitly :t:`[use capture]s` all :t:`[type parameter]s` and :t:`[constant parameter]s` that are in :t:`scope`.
 
 :dp:`fls_iT9WCNfUZQnC`
-An :t:`anonymous return type` behaves as if it contained all its :t:`[use capture]s`.
+An :t:`anonymous return type` behaves as if it contains all its :t:`[use capture]s`.
 
 .. rubric:: Examples
 
@@ -3018,7 +3018,7 @@ A :t:`lifetime bound` shall apply to :t:`[type]s` and other :t:`[lifetime]s`.
    &'static Shape
 
 :dp:`fls_gcszhqg6hnva`
-See :p:`fls_85vx1qfa061i` for the declaration of ``Shape``.
+See :p:`fls_mjg7yrq66hh0` for the declaration of ``Shape``.
 
 .. _fls_ikfvbeewame7:
 


### PR DESCRIPTION
This PR fixes various small issues in the FLS, in particular:
* Alphabetize lists of certain attributes.
* Place section Raw Borrow Expression immediately after Borrow Expression.
* Fix spelling errors in comment-related rules.
* Alphabetize syntactic productions in Types and Traits.
* Minor wording improvements in Types and Traits.
* Fix broken link to a paragraph in Types and Traits.