### PR TITLE
[Change]: [1.93] Allow const items with mutable refs to statics

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -35,6 +35,14 @@ Language changes in Rust 1.93.0
 - `During const-evaluation, support copying pointers byte-by-byte <https://github.com/rust-lang/rust/pull/148259>`_
 - `LUB coercions now correctly handle function item types, and functions with differing safeties <https://github.com/rust-lang/rust/pull/148602>`_
 - `Allow const items that contain mutable references to static (which is *very* unsafe, but not *always* UB) <https://github.com/rust-lang/rust/pull/148746>`_
+
+  * Removed paragraph: :p:`fls_ooOYxhVh8hZo`
+  * Removed paragraph: :p:`fls_zkNFeBLy80UA`
+  * Removed paragraph: :p:`fls_VhzGfnWg7YrG`
+  * Removed paragraph: :p:`fls_qC6L0km0ZMFI`
+  * Removed paragraph: :p:`fls_ibYKKQdB2tDn`
+  * Removed paragraph: :p:`fls_dQdSxf8kOgbi`
+
 - `Add warn-by-default const_item_interior_mutations lint to warn against calls which mutate interior mutable const items <https://github.com/rust-lang/rust/pull/148407>`_
 
   - Lints are outside the scope of FLS

--- a/src/values.rst
+++ b/src/values.rst
@@ -111,26 +111,6 @@ The :t:`expression` of a :t:`constant initializer` shall be a
 The value of a :t:`constant` is determined by evaluating its
 :t:`constant initializer`.
 
-:dp:`fls_ooOYxhVh8hZo`
-After :t:`type coercion`, the value of the constant cannot contain any
-:t:`[mutable reference]s`, except when
-
-- :dp:`fls_zkNFeBLy80UA`
-  The :t:`mutable reference` is contained within an :t:`external static`, or
-
-- :dp:`fls_VhzGfnWg7YrG`
-  The :t:`mutable reference` is contained within a :t:`mutable static`, or
-
-- :dp:`fls_qC6L0km0ZMFI`
-  The :t:`mutable reference` is contained within a :t:`static`
-  whose type is subject to :t:`interior mutability`, or
-
-- :dp:`fls_ibYKKQdB2tDn`
-  The :t:`mutable reference` is contained within an :t:`union`, or
-
-- :dp:`fls_dQdSxf8kOgbi`
-  The :t:`referent` is a value of a :t:`zero-sized type`.
-
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_xezt9hl069h4`


### PR DESCRIPTION
This PR modifies section "Constants" from chapter "Values" to remove the paragraphs which specified the circumstances under which a constant can contain mutable references, as there are no such restrictions in 1.93.

Issue: https://github.com/rust-lang/fls/issues/650