### PR TITLE
[Change]: [1.93] Stabilize ABI of C-style variadic function declarations

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -27,6 +27,9 @@ Language changes in Rust 1.93.0
   - No change: the target is outside the scope of FLS
 
 - `Stabilize declaration of C-style variadic functions for the system ABI <https://github.com/rust-lang/rust/pull/145954>`_
+
+  - Changed paragraph: :p:`fls_8m7pc3riokst`
+
 - `Emit error when using some keyword as a cfg predicate <https://github.com/rust-lang/rust/pull/146978>`_
 
   - No change: this bug was not documented in FLS

--- a/src/ffi.rst
+++ b/src/ffi.rst
@@ -74,7 +74,7 @@ The following :t:`[ABI]s` are supported:
   :dt:`Rust ABI`.
 
 * :dp:`fls_8m7pc3riokst`
-  ``extern "system"`` - The operating system-dependent :t:`ABI`.
+  ``extern "system"`` - The operating system-dependent :t:`ABI`. This :t:`ABI kind` is equivalent to ``extern "C"`` except on Windows x86_32 where it is equivalent to ``extern "stdcall"`` for non-:t:`[variadic function]s`, and equivalent to ``extern "C"`` for :t:`[variadic function]s`.
 
 * :dp:`fls_NQAzj5ai1La5`
   ``extern "system-unwind"`` - The same as ``extern "system"`` with the
@@ -108,6 +108,9 @@ include, but may not be limited to, the following:
   ``extern "cdecl-unwind"`` - The same as ``extern "cdecl"``
   with the addition that unwinding across FFI is permitted.
 
+* :dp:`fls_JHlqXjn4Sf07`
+  ``extern "efiapi"`` - The :t:`ABI` for `UEFI <https://uefi.org/specifications>`_.
+
 * :dp:`fls_6rtj6rwqxojh`
   ``extern "fastcall"`` - The ``fastcall`` :t:`ABI` that corresponds to MSVC's
   ``__fastcall`` and GCC and clang's ``__attribute__((fastcall))``.
@@ -132,9 +135,6 @@ include, but may not be limited to, the following:
 * :dp:`fls_xrCRprWS13R1`
   ``extern "win64-unwind"`` - The same as ``extern "win64"``
   with the addition that unwinding across FFI is permitted.
-
-* :dp:`fls_JHlqXjn4Sf07`
-  ``extern "efiapi"`` - The :t:`ABI` for `UEFI <https://uefi.org/specifications>`_.
 
 .. rubric:: Undefined Behavior
 


### PR DESCRIPTION
This PR clarifies the semantics of the `extern "system"` ABI kind.

Issue: https://github.com/rust-lang/fls/issues/646