### PR TITLE
[Change]: [1.93] During const-evaluation, support copying pointers by…

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -36,6 +36,9 @@ Language changes in Rust 1.93.0
 
 - `Stabilize asm_cfg <https://github.com/rust-lang/rust/pull/147736>`_
 - `During const-evaluation, support copying pointers byte-by-byte <https://github.com/rust-lang/rust/pull/148259>`_
+
+  * No change: Already covered by the classification of :t:`[constant expression]s`.
+
 - `LUB coercions now correctly handle function item types, and functions with differing safeties <https://github.com/rust-lang/rust/pull/148602>`_
 - `Allow const items that contain mutable references to static (which is *very* unsafe, but not *always* UB) <https://github.com/rust-lang/rust/pull/148746>`_
 


### PR DESCRIPTION
…te-by-byte

This PR updates the changelog only, as the FLS text already reflects to correct semantics.

Issue: https://github.com/rust-lang/fls/issues/648