### PR TITLE
[Change]: [1.94.0] Update to Unicode 17

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -26,6 +26,11 @@ Language changes in Rust 1.94.0
 - `Stabilize additional 29 RISC-V target features including large portions of the RVA22U64 / RVA23U64 profiles <https://github.com/rust-lang/rust/pull/145948>`_
 - `Add warn-by-default unused_visibilities lint for visibility on const _ declarations <https://github.com/rust-lang/rust/pull/147136>`_
 - `Update to Unicode 17 <https://github.com/rust-lang/rust/pull/148321>`_
+
+  - Changed paragraphs:
+
+    - :p:`fls_jpecw46eh061`
+
 - `Avoid incorrect lifetime errors for closures <https://github.com/rust-lang/rust/pull/148329>`_
 
 Language changes in Rust 1.93.1

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -476,7 +476,7 @@ keyword]s`.
 
 :dp:`fls_jpecw46eh061`
 A :t:`pure identifier` shall follow the specification in Unicode Standard Annex
-#31 for :t:`Unicode` version 16.0, with the following profile:
+#31 for :t:`Unicode` version 17.0, with the following profile:
 
 * :dp:`fls_lwcflgezgs5z`
   ``Start`` = ``XID_Start``, plus character 0x5F (low line).


### PR DESCRIPTION
This PR updates the FLS to use Unicode 17 in its identifiers.

Closes: https://github.com/rust-lang/fls/issues/673