### PR TITLE
[Change]: [1.94.0] Add warn-by-default unused_visibilities lint

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -25,6 +25,9 @@ Language changes in Rust 1.94.0
 - `Impls and impl items inherit dead_code lint level of the corresponding traits and trait items <https://github.com/rust-lang/rust/pull/144113>`_
 - `Stabilize additional 29 RISC-V target features including large portions of the RVA22U64 / RVA23U64 profiles <https://github.com/rust-lang/rust/pull/145948>`_
 - `Add warn-by-default unused_visibilities lint for visibility on const _ declarations <https://github.com/rust-lang/rust/pull/147136>`_
+
+  - No change: Lints are not part of the FLS
+
 - `Update to Unicode 17 <https://github.com/rust-lang/rust/pull/148321>`_
 - `Avoid incorrect lifetime errors for closures <https://github.com/rust-lang/rust/pull/148329>`_
 


### PR DESCRIPTION
This PR updates the changelog of the FLS to indicate that the related rust-lang PR does not fall within the scope of the FLS.

Closes: https://github.com/rust-lang/fls/issues/672