### PR TITLE
[Change]: [1.94.0] Avoid incorrect lifetime errors for closures

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -42,6 +42,8 @@ Language changes in Rust 1.94.0
 
 - `Avoid incorrect lifetime errors for closures <https://github.com/rust-lang/rust/pull/148329>`_
 
+  - No change: the exact machanics of the borrow checker are outside the scope of the FLS
+
 Language changes in Rust 1.93.1
 -------------------------------
 


### PR DESCRIPTION
This PR updates the changelog of the FLS to indicate that the related rust-lang PR does not fall within the scope of the FLS.

Closes: https://github.com/rust-lang/fls/issues/674