### PR TITLE
remove needless ids (from glossary)

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -58,4 +58,4 @@ html_short_title = "FLS"
 
 lint_alphabetical_section_titles = ["glossary"]
 
-lint_no_paragraph_ids = ["index", "changelog"]
+lint_no_paragraph_ids = ["index", "changelog", "glossary"]

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -6,7863 +6,5199 @@
 
 .. informational-page::
 
-.. _fls_bc2qwbfibrcs:
-
 Glossary
 ========
-
-.. _fls_m98yg554tj9s:
 
 ABI
 ^^^
 
-:dp:`fls_4ko8qcah0f9k`
 For :dt:`ABI`, see :t:`Application Binary Interface`.
-
-.. _fls_zOdDwoObYHC0:
 
 ABI clobber
 ^^^^^^^^^^^
 
-:dp:`fls_OVX4RFcWKfP9`
 An :dt:`ABI clobber` is an argument to :t:`macro` :std:`core::arch::asm` which
 indicates that the :t:`[value]s` of selected :t:`[register]s` might be
 overwritten during the :t:`execution` of an :t:`assembly code block`.
 
-:dp:`fls_pMNTKjDMCHia`
 See :s:`AbiClobber`.
-
-.. _fls_g791aj7w5iz1:
 
 ABI kind
 ^^^^^^^^
 
-:dp:`fls_qo9itrt0n3h8`
 The :dt:`ABI kind` indicates the :t:`ABI` of a :t:`construct`.
 
-:dp:`fls_rd4kpubxygie`
 See :s:`AbiKind`.
-
-.. _fls_ymnz0mt7i4m8:
 
 abort
 ^^^^^
 
-:dp:`fls_u4o7tda3ilv0`
 :dt:`Abort` is the immediate termination of a program.
-
-.. _fls_g40une2uudez:
 
 abstract data type
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_64drmro2fcfo`
 An :dt:`abstract data type` is a collection of other :t:`[type]s`.
-
-.. _fls_5fu0ncvnjyna:
 
 active attribute
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_r8rzj8mtxtp1`
 An :dt:`active attribute` is an :t:`attribute` that is removed from the
 :t:`item` it decorates.
-
-.. _fls_xqZapSv9tM1F:
 
 addition assignment
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_FVgKeCXlmuPe`
 For :dt:`addition assignment`, see :t:`addition assignment expression`.
-
-.. _fls_iw30dqjaeqle:
 
 addition assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_w83tf9m7vu67`
 An :dt:`addition assignment expression` is a
 :t:`compound assignment expression` that uses addition.
 
-:dp:`fls_hihh97p0rnt8`
 See :s:`AdditionAssignmentExpression`.
-
-.. _fls_mcabdigrqv21:
 
 addition expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ylfdtuajmi0t`
 An :dt:`addition expression` is an :t:`arithmetic expression` that uses
 addition.
 
-:dp:`fls_5bgx5dyi817x`
 See :s:`AdditionExpression`.
-
-.. _fls_wbdlbe61de3t:
 
 adjusted call operand
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mchqbc64iu0u`
 An :dt:`adjusted call operand` is a :t:`call operand` adjusted with inserted :t:`[borrow expression]s` and :t:`[dereference expression]s`.
-
-.. _fls_j775guurkgo4:
 
 alignment
 ^^^^^^^^^
 
-:dp:`fls_c0hbatn5o8x3`
 The :dt:`alignment` of a :t:`value` specifies which addresses are valid for
 storing the value.
-
-.. _fls_jZKpckU1t2lR:
 
 all configuration predicate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_IyMZWiTnkYPv`
 An :dt:`all configuration predicate` is a :t:`configuration predicate` that
 models existential quantifier ALL.
 
-:dp:`fls_0fEw9Bx8xX8q`
 See :s:`ConfigurationPredicateAll`.
-
-.. _fls_du8uevac5q7j:
 
 anonymous loop expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_csss2a8yk52k`
 An :dt:`anonymous loop expression` is a :t:`loop expression` without a
 :t:`label`.
-
-.. _fls_dgxkklxcrrl0:
 
 anonymous return type
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_z6t6lbwwztuf`
 An :dt:`anonymous return type` is an :t:`impl trait type` ascribed to a
 :t:`function` return type.
-
-.. _fls_8oepaq6ang93:
 
 anonymous type parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_brqaq0736o09`
 An :dt:`anonymous type parameter` is an :t:`impl trait type` ascribed to a
 :t:`function parameter`.
-
-.. _fls_jrzM6C5B6AMt:
 
 any configuration predicate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_0nWHML8eoozG`
 An :dt:`any configuration predicate` is a :t:`configuration predicate` that
 models existential quantifier ANY.
 
-:dp:`fls_xhhXonDldWQY`
 See :s:`ConfigurationPredicateAny`.
-
-.. _fls_pcum2wpmgskk:
 
 Application Binary Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ew4babc9467c`
 :dt:`Application Binary Interface` is a set of conventions that dictate how
 data and computation cross language boundaries.
 
-:dp:`fls_8dgmmsp34lgc`
 See :s:`AbiSpecification`.
-
-.. _fls_dd008npswhij:
 
 argument operand
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_ljuwr88k92vp`
 An :dt:`argument operand` is an :t:`operand` which is used as an argument in a
 :t:`call expression` or a :t:`method call expression`.
-
-.. _fls_kf81ozijral2:
 
 arithmetic expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_u3z2r1fw89xo`
 An :dt:`arithmetic expression` is an :t:`expression` that computes a :t:`value`
 from two :t:`[operand]s` using arithmetic.
 
-:dp:`fls_in59ccg4g3we`
 See :s:`ArithmeticExpression`.
-
-.. _fls_kSuc3Gi7cdly:
 
 arithmetic operator
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Qf7DckakqvRq`
 An :dt:`arithmetic operator` is the operator of an :t:`arithmetic expression`.
-
-.. _fls_vZ1H57x9OFSZ:
 
 arithmetic overflow
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_jbytOQvIddAl`
 An :dt:`arithmetic overflow` occurs if an :t:`arithmetic expression` or a
 :t:`negation expression` computes a :t:`value` of a :t:`scalar type` that lies
 outside of the range of valid :t:`[value]s` for the :t:`scalar type`.
 
-.. _fls_9aice4qbiqxf:
-
 arity
 ^^^^^
 
-:dp:`fls_dl2gkip00bua`
 An :dt:`arity` is the number of :t:`[tuple field]s` in a :t:`tuple type`.
-
-.. _fls_bn1regeucxqi:
 
 array
 ^^^^^
 
-:dp:`fls_metry7a5prpt`
 An :dt:`array` is a :t:`value` of an :t:`array type`.
-
-.. _fls_2d9fee2o9:
 
 array element constructor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_cmx9ls5zoazp`
 An :dt:`array element constructor` is an :t:`array expression` that lists all
 elements of the :t:`array` being constructed.
 
-:dp:`fls_9bwte7cmszl1`
 See :s:`ArrayElementConstructor`.
-
-.. _fls_yvzpqb192pci:
 
 array expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_pyjkjbvqarto`
 An :dt:`array expression` is an :t:`expression` that constructs an :t:`array`.
 
-:dp:`fls_vua1xy4y9irp`
 See :s:`ArrayExpression`.
-
-.. _fls_6jkgj61m49vg:
 
 array repetition constructor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_st1kw8mor2zk`
 An :dt:`array repetition constructor` is an :t:`array expression` that
 specifies how many times an element is repeated in the :t:`array` being
 constructed.
 
-:dp:`fls_1zr997qwsal2`
 See :s:`ArrayRepetitionConstructor`.
-
-.. _fls_15gzlmwuu4pk:
 
 array type
 ^^^^^^^^^^
 
-:dp:`fls_muddb5qxdc4k`
 An :dt:`array type` is a :t:`sequence type` that represents a fixed sequence of
 elements.
 
-:dp:`fls_wre34hexlv6s`
 See :s:`ArrayTypeSpecification`.
-
-.. _fls_et0NKXAYyDmh:
 
 assembly code block
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_d1ojwFwKpvm3`
 An :dt:`assembly code block` is a sequence of :t:`[assembly instruction]s`.
 
-:dp:`fls_gXVUuW6iyNhZ`
 See :s:`AssemblyCodeBlock`.
-
-.. _fls_iUnmWXxcuzif:
 
 assembly directive
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_FP2KbO6c3cpq`
 An :dt:`assembly directive` is a request to the assembler to perform a
 particular action or change a setting.
-
-.. _fls_HliSgbSzPO2r:
 
 assembly instruction
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_VLu28hOvCy2o`
 An :dt:`assembly instruction` is a :t:`string literal` that represents a
 low-level assembly operation or an :t:`assembly directive`.
 
-:dp:`fls_EYHuB5cCldbm`
 See :s:`AssemblyInstruction`.
-
-.. _fls_1iVIUoVDsYph:
 
 assembly option
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_F5I3okDKIYnE`
 An :dt:`assembly option` is used to specify a characteristic of or a restriction
 on the related :t:`assembly code block`.
 
-:dp:`fls_31NQgPGb73Hy`
 See :s:`AssemblyOption`.
-
-.. _fls_l78iam7w8w38:
 
 assigned operand
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_g714mnh7s7fx`
 An :dt:`assigned operand` is the target :t:`operand` of a
 :t:`compound assignment expression`.
 
-:dp:`fls_z0amfuj9vsqe`
 See :s:`AssignedOperand`.
-
-.. _fls_m1mim5qdzf2u:
 
 assignee expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wpmcexvbynbu`
 An :dt:`assignee expression` is an :t:`expression` that appears as the
 :t:`left operand` of an :t:`assignment expression`.
-
-.. _fls_3hs9hqsthil1:
 
 assignee operand
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_4tgf0wu2mr3l`
 An :dt:`assignee operand` is the target :t:`operand` of an
 :t:`assignment expression`.
 
-:dp:`fls_df0j0vnnq20a`
 See :s:`AssigneeOperand`.
-
-.. _fls_f6ztsofr6xa9:
 
 assignment
 ^^^^^^^^^^
 
-:dp:`fls_j9pyuucyplmi`
 See :t:`assignment expression`.
-
-.. _fls_2d2elg5eukv4:
 
 assignment expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6jkc6a6me3zr`
 An :dt:`assignment expression` is an :t:`expression` that assigns the
 :t:`value` of a :t:`value operand` to an :t:`assignee operand`.
 
-:dp:`fls_njw68i3bp9qq`
 See :s:`AssignmentExpression`.
-
-.. _fls_pjb22ylz5swp:
 
 associated constant
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hi9qa0k2nujb`
 An :dt:`associated constant` is a :t:`constant` that appears as an
 :t:`associated item`.
-
-.. _fls_vxiitesidcc2:
 
 associated function
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_zcy5pat39bq7`
 An :dt:`associated function` is a :t:`function` that appears as an
 :t:`associated item`.
-
-.. _fls_9mcx6h6irrlx:
 
 associated implementation constant
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rfaxcrrrb5q9`
 An :dt:`associated implementation constant` is an :t:`associated constant` that
 appears within an :t:`implementation`.
-
-.. _fls_n85fwe75ku60:
 
 associated implementation function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7xbmvl3jrc27`
 An :dt:`associated implementation function` is an :t:`associated function` that
 appears within an :t:`implementation`.
-
-.. _fls_c0hekhwpznyq:
 
 associated implementation type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6g5t81gx9ayx`
 An :dt:`associated implementation type` is an :t:`associated type` that appears
 within an :t:`implementation`.
-
-.. _fls_f3ferow5ugp:
 
 associated item
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_o5ysjk7l91ni`
 An :dt:`associated item` is an :t:`item` that appears within an
 :t:`implementation` or a :t:`trait`.
 
-:dp:`fls_44vtqu7tvhi2`
 See :s:`AssociatedItem`.
-
-.. _fls_8p8teeamua55:
 
 associated trait constant
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xhhsej8db74y`
 An :dt:`associated trait constant` is an :t:`associated constant` that appears
 within a :t:`trait`.
-
-.. _fls_4h7s8u1zumnq:
 
 associated trait function
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_r927r0pdkb6h`
 An :dt:`associated trait function` is an :t:`associated function` that appears
 within a :t:`trait`.
-
-.. _fls_fufF4UmzLg5G:
 
 associated trait implementation function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_bzdXloUGlVSC`
 An :dt:`associated trait implementation function` is an :t:`associated function`
 that appears within a :t:`trait implementation`.
-
-.. _fls_47xtji9Pk8Lw:
 
 associated trait implementation item
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_PaENehzTVgfB`
 An :dt:`associated trait implementation item` is an :t:`associated item` that
 appears within a :t:`trait implementation`.
-
-.. _fls_J946yIcmlAyV:
 
 associated trait item
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_IlRrVLm05GTf`
 An :dt:`associated trait item` is an :t:`associated item` that appears
 within a :t:`trait`.
-
-.. _fls_azz308k3ra99:
 
 associated trait type
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_dndsgkiq9r7i`
 An :dt:`associated trait type` is an :t:`associated type` that appears within
 a :t:`trait`.
-
-.. _fls_zfs68g3yk0uw:
 
 associated type
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_rs0n72c2d8f`
 An :dt:`associated type` is a :t:`type alias` that appears as an
 :t:`associated item`.
-
-.. _fls_zOe783MlE9i9:
 
 associated type projection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_4moFUY6epk0v`
 An :dt:`associated type projection` is a :t:`qualified type path` of the form
 ``<type as trait>::associated_type``, where ``type`` is a :t:`type`, ``trait``
 is a :t:`qualifying trait`, and ``associated type`` is an :t:`associated type`.
 
-.. _fls_fczijre8123c:
-
 associativity
 ^^^^^^^^^^^^^
 
-:dp:`fls_7i7o23mi2i33`
 :dt:`Associativity` is the order by which :t:`[operand]s` are evaluated within
 a single :t:`expression`.
-
-.. _fls_9speqyus5ku3:
 
 async block
 ^^^^^^^^^^^
 
-:dp:`fls_pf6lrmcjywoj`
 For :dt:`async block`, see :t:`async block expression`.
-
-.. _fls_n5m58be9jnjj:
 
 async block expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_p6nvfs7bfoxd`
 An :dt:`async block expression` is a :t:`block expression` that is specified
 with :t:`keyword` ``async`` and encapsulates behavior which is executed in
 an asynchronous manner.
 
-:dp:`fls_je689rormhd6`
 See :s:`AsyncBlockExpression`.
-
-.. _fls_oUdQnbW1MAFW:
 
 async closure expression
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_SxydbQPPX9Jw`
 An :dt:`async closure expression` is a :t:`closure expression` subject to keyword ``async`` that defines an :t:`async closure type` and constructs a value of that :t:`type`.
 
-:dp:`fls_JZsDFMg85a3u`
 See :s:`ClosureExpression`.
-
-.. _fls_Pq4ohvrMOi5p:
 
 async closure type
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_IT28HJaF8rnm`
 An :dt:`async closure type` is a unique anonymous :t:`function type` that encapsulates
 all :t:`[capture target]s` of a :t:`closure expression` producing a :std:`core::future::Future`.
 
 
-.. _fls_lYrTaCM1LcXU:
-
 async control flow boundary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_EXoGOkCRsfKK`
 An :dt:`async control flow boundary` is a :t:`control flow boundary` that
 additionally allows the suspension of execution via :t:`[await expression]s`.
-
-.. _fls_nlafxy2z1moc:
 
 async function
 ^^^^^^^^^^^^^^
 
-:dp:`fls_gv9wl1cbaw1g`
 An :dt:`async function` is a :t:`function` subject to :t:`keyword` ``async``.
-
-.. _fls_yikjq8yn3nnh:
 
 atomic
 ^^^^^^
 
-:dp:`fls_9xd3m2qvqzk`
 See :t:`atomic type`.
-
-.. _fls_197vnaw2zbnc:
 
 atomic type
 ^^^^^^^^^^^
 
-:dp:`fls_cycpv4fopgx2`
 An :dt:`atomic type` is a :t:`type` defined in :t:`module`
 :std:`core::sync::atomic`.
-
-.. _fls_w1plocebd7kg:
 
 attribute
 ^^^^^^^^^
 
-:dp:`fls_o74rfpe6zo6a`
 An :dt:`attribute` is a general, free-form metadatum that is interpreted based
 on its name, convention, language, and tool.
-
-.. _fls_SsMRqkHLDAgG:
 
 attribute content
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_sn0GvVmM3o38`
 An :dt:`attribute content` is a :t:`construct` that provides the content of
 an :t:`attribute`.
 
-:dp:`fls_YwyrWC8fcmRm`
 See :s:`AttributeContent`.
-
-.. _fls_x1fafbpo0mlu:
 
 attribute macro
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_mtqr4d817ikn`
 An :dt:`attribute macro` is a :t:`procedural macro` that consumes two streams
 of :t:`[token]s` to produce a stream of tokens, and defines a new
 :t:`outer attribute` that can be attached to :t:`[item]s`.
 
-.. _fls_24iVIlHhvnVO:
-
 auto trait
 ^^^^^^^^^^
 
-:dp:`fls_d84nTOR4pZq5`
 An :dt:`auto trait` is a :t:`trait` that is implicitly and automatically
 implemented by a :t:`type` when the types of its constituent :t:`[field]s`
 implement the :t:`trait`.
 
-.. _fls_n4oo89apywk4:
-
 await expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_psbc3b8pec47`
 An :dt:`await expression` is an :t:`expression` that polls a :t:`future`,
 suspending the execution of the future until the future is ready.
 
-:dp:`fls_29gkp9bpo1hi`
 See :s:`AwaitExpression`.
-
-.. _fls_a8tavqxuvaju:
 
 base initializer
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_dnuwn2tnvtgy`
 A :dt:`base initializer` is a :t:`construct` that specifies an :t:`enum value`,
 a :t:`struct value`, or a :t:`union value` to be used as a base for
 construction in a :t:`struct expression`.
 
-:dp:`fls_mprzem71zlhy`
 See :s:`BaseInitializer`.
-
-.. _fls_bii5eu1wznzk:
 
 basic assignment
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_byq9e2jf8r22`
 A :dt:`basic assignment` is an :t:`assignment expression` that is not a
 :t:`destructuring assignment`.
-
-.. _fls_kahj3y4rvmvb:
 
 binary crate
 ^^^^^^^^^^^^
 
-:dp:`fls_8gfe7hajxkd7`
 A :dt:`binary crate` is a :t:`crate` whose :t:`crate type` is ``bin``.
-
-.. _fls_or4o65fyt28y:
 
 binary literal
 ^^^^^^^^^^^^^^
 
-:dp:`fls_hy54uj6u3nqw`
 A :dt:`binary literal` is an :t:`integer literal` in base 2.
 
-:dp:`fls_693r7vs2s7o7`
 See :s:`BinaryLiteral`.
-
-.. _fls_xydujcfvvb8p:
 
 binary operator
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_v0he0zp9ph7a`
 A :dt:`binary operator` is an operator that operates on two :t:`[operand]s`.
-
-.. _fls_jrelzibadg7b:
 
 binding
 ^^^^^^^
 
-:dp:`fls_89qi3unjvwd7`
 A :dt:`binding` of a :t:`binding pattern` binds a matched :t:`value` to a
 :t:`name`.
 
-:dp:`fls_lujdci4bphek`
 See :s:`Binding`.
-
-.. _fls_glblhx8vzd3z:
 
 binding argument
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_9lzcasl4tw7k`
 A :dt:`binding argument` is a :t:`generic argument` that supplies the :t:`type`
 of an :t:`associated trait type`.
-
-.. _fls_t2cit5QOte8U:
 
 binding bound argument
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_D3i3n4RIReCA`
 A :dt:`binding bound argument` is a :t:`generic argument` that further imposes
 :t:`[bound]s` on an :t:`associated trait type`.
-
-.. _fls_bv1k866tai6j:
 
 binding mode
 ^^^^^^^^^^^^
 
-:dp:`fls_e3uvvvvyzq8h`
 :dt:`Binding mode` is the mechanism by which a matched :t:`value` is bound to a
 :t:`binding` of a :t:`pattern`.
-
-.. _fls_1nw19qc14zg6:
 
 binding pattern
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_ancqgz8pybbe`
 A :dt:`binding pattern` is either an :t:`identifier pattern` or a
 :t:`shorthand deconstructor`.
-
-.. _fls_5ep4xSGZwtoL:
 
 binding scope
 ^^^^^^^^^^^^^
 
-:dp:`fls_6qPYH5NJ8usI`
 A :dt:`binding scope` is a :t:`scope` for :t:`[binding]s`.
-
-.. _fls_clut5DWMQin8:
 
 bit and assignment
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wIl0K7O6lTXJ`
 For :dt:`bit and assignment`, see :t:`bit and assignment expression`.
-
-.. _fls_y72vyr2tmdyb:
 
 bit and assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_dvqotpte0pc2`
 A :dt:`bit and assignment expression` is a :t:`compound assignment expression`
 that uses bit and arithmetic.
 
-:dp:`fls_ix9ecb5olcx`
 See :s:`BitAndAssignmentExpression`.
-
-.. _fls_h6sh4im3gjys:
 
 bit and expression
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_c1g5gljnr9kz`
 A :dt:`bit and expression` is a :t:`bit expression` that uses bit and
 arithmetic.
 
-:dp:`fls_vbsvu0troqci`
 See :s:`BitAndExpression`.
-
-.. _fls_ed6yltkt0gb1:
 
 bit expression
 ^^^^^^^^^^^^^^
 
-:dp:`fls_b3p5xqsfolqo`
 A :dt:`bit expression` is an :t:`expression` that computes a :t:`value` from
 two :t:`[operand]s` using bit arithmetic.
 
-:dp:`fls_iw1k2cfwfjou`
 See :s:`BitExpression`.
-
-.. _fls_90E3eiBYgicI:
 
 bit or assignment
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_21iFIDCu7Pk4`
 For :dt:`bit or assignment`, see :t:`bit or assignment expression`.
-
-.. _fls_ehorb0lul906:
 
 bit or assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tu1owkfk0lu0`
 A :dt:`bit or assignment expression` is a :t:`compound assignment expression`
 that uses bit or arithmetic.
 
-:dp:`fls_utjcsfz8up88`
 See :s:`BitOrAssignmentExpression`.
-
-.. _fls_m33m8nd2rnf8:
 
 bit or expression
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_183aem60of9o`
 A :dt:`bit or expression` is a :t:`bit expression` that uses bit or arithmetic.
 
-:dp:`fls_ctqsjp653tbt`
 See :s:`BitOrExpression`.
-
-.. _fls_jEnv7RjEUZvm:
 
 bit xor assignment
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_VJpCPVCuszs1`
 For :dt:`bit xor assignment`, see :t:`bit xor assignment expression`.
-
-.. _fls_u3fcq7jjyxux:
 
 bit xor assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ma980ujltab2`
 A :dt:`bit xor assignment expression` is a :t:`compound assignment expression`
 that uses bit exclusive or arithmetic.
 
-:dp:`fls_lcrd0birf0un`
 See :s:`BitXorAssignmentExpression`.
-
-.. _fls_ixw1601j8u39:
 
 bit xor expression
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_kccsvtzfhbp1`
 A :dt:`bit xor expression` is a :t:`bit expression` that uses bit exclusive or
 arithmetic.
 
-:dp:`fls_6qulwlo43w6m`
 See :s:`BitXorExpression`.
-
-.. _fls_aa980vviqjue:
 
 block comment
 ^^^^^^^^^^^^^
 
-:dp:`fls_a0ejcfs7y5uy`
 A :dt:`block comment` is a :t:`comment` that spans one or more :t:`[line]s`.
 
-:dp:`fls_21r4tblk8awi`
 See :s:`BlockComment`.
-
-.. _fls_c5qn7wjk0mnx:
 
 block expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_gvjvzxi2xps4`
 A :dt:`block expression` is an :t:`expression` that sequences expressions and
 :t:`[statement]s`.
 
-:dp:`fls_h8j9t2xq2i1u`
 See :s:`BlockExpression`.
-
-.. _fls_n485t6wcgx07:
 
 bool
 ^^^^
 
-:dp:`fls_wtmaf5amvleh`
 :dc:`bool` is a :t:`type` whose :t:`[value]s` denote the truth values of logic
 and Boolean algebra.
-
-.. _fls_oz4tdyp3rvm4:
 
 boolean literal
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_5mrxdqh474vk`
 A :dt:`boolean literal` is a :t:`literal` that denotes the truth :t:`[value]s`
 of logic and Boolean algebra.
 
-:dp:`fls_i13qcchm9vkk`
 See :s:`BooleanLiteral`.
-
-.. _fls_7ef4c6ss7m6i:
 
 borrow
 ^^^^^^
 
-:dp:`fls_2tpbdddvrl2f`
 A :dt:`borrow` is a :t:`reference` produced by :t:`borrowing`.
-
-.. _fls_u0hymkjwyur7:
 
 borrow expression
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2f55piwg78ru`
 A :dt:`borrow expression` is an :t:`expression` that borrows the :t:`value`
 of its :t:`operand` and creates a :t:`reference` to the memory location of its
 operand.
 
-:dp:`fls_c3hydbp2exok`
 See :s:`BorrowExpression`.
-
-.. _fls_gl84828b074a:
 
 borrowed
 ^^^^^^^^
 
-:dp:`fls_3gnps2s95ck4`
 A memory location is :dt:`borrowed` when a :t:`reference` pointing to it is
 :t:`active`.
-
-.. _fls_95c5cbc2jvpc:
 
 borrowing
 ^^^^^^^^^
 
-:dp:`fls_2epblwd2slp8`
 :dt:`Borrowing` is the process of temporarily associating a :t:`reference` with
 a :t:`value` without transferring :t:`ownership` permanently.
-
-.. _fls_ehfvcdpo3l4a:
 
 bound
 ^^^^^
 
-:dp:`fls_q6mxhn1fxjs6`
 A :dt:`bound` imposes a constraint on a :t:`generic parameter` by limiting the
 set of possible :t:`[generic substitution]s`.
 
-:dp:`fls_rxabhhigp5uy`
 See :s:`TypeBound`.
-
-.. _fls_jlfqyn3enrsi:
 
 bound pattern
 ^^^^^^^^^^^^^
 
-:dp:`fls_uusfbosjwyd1`
 A :dt:`bound pattern` is a :t:`pattern` that imposes a constraint on a related
 :t:`identifier pattern`.
 
-:dp:`fls_oszhit2crxzc`
 See :s:`BoundPattern`.
-
-.. _fls_xki2cerozblt:
 
 break expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_8ys8hlqgizoa`
 A :dt:`break expression` is an :t:`expression` that terminates a
 :t:`loop expression` or a :t:`named block expression`.
 
-:dp:`fls_fd1xpst5fki2`
 See :s:`BreakExpression`.
-
-.. _fls_ff2zt3ww2yw3:
 
 break type
 ^^^^^^^^^^
 
-:dp:`fls_jvm1vsqmslxn`
 :dt:`Break type` is the :t:`type` of the :t:`operand` of a
 :t:`break expression`.
-
-.. _fls_owtptuvleeb:
 
 break value
 ^^^^^^^^^^^
 
-:dp:`fls_kpka4jf2qr5l`
 :dt:`Break value` is the :t:`value` of the :t:`operand` of a
 :t:`break expression`.
-
-.. _fls_82ev7wknxqmk:
 
 built-in attribute
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_a40rclur4orm`
 A :dt:`built-in attribute` is a language-defined :t:`attribute`.
 
-:dp:`fls_ooq5g8zffyfb`
 See :s:`InnerBuiltinAttribute`, :s:`OuterBuiltinAttribute`.
-
-.. _fls_QzAif2NyVJbk:
 
 built-in trait
 ^^^^^^^^^^^^^^
 
-:dp:`fls_IgzD9l8o6R50`
 A :dt:`built-in trait` is a language-defined :t:`trait`.
-
-.. _fls_e8rokiw23i9t:
 
 byte literal
 ^^^^^^^^^^^^
 
-:dp:`fls_l67oo0u12zjb`
 A :dt:`byte literal` is a :t:`literal` that denotes a fixed byte :t:`value`.
 
-:dp:`fls_iu9twvm648dx`
 See :s:`ByteLiteral`.
-
-.. _fls_uwe7iomhvgtp:
 
 byte string literal
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_my4r1l3ilyt2`
 A :dt:`byte string literal` is a :t:`literal` that consists of multiple
 :s:`[AsciiCharacter]s`.
 
-:dp:`fls_4yhag19z61bl`
 See :s:`ByteStringLiteral`.
-
-.. _fls_lfjgrkwra22i:
 
 C
 ^
 
-:dp:`fls_d4q2ro4nsnop`
 :dt:`C` is the programming language described in the ISO/IEC 9899:2018
 International Standard.
-
-.. _fls_wenn1wdsicfz:
 
 C representation
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_g9pdb06m5fto`
 :dt:`C representation` is a :t:`type representation` that lays out :t:`[type]s`
 such that they are interoperable with the :t:`C` language.
-
-.. _fls_fls_J0xUy4Mcxoe6:
 
 C signed int type
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8QIcvapJehqY`
 :dt:`C signed int type` is the `signed int` :t:`type` of the :t:`C` language.
-
-.. _fls_roz4WXH5JZFj:
 
 c string literal
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_g3NHtaOhTB7g`
 A :dt:`c string literal` is a :t:`literal` that consists of multiple characters
 with an implicit 0x00 byte appended to it.
 
-:dp:`fls_FZ6QSpjmVme5`
 See :s:`CStringLiteral`.
-
-.. _fls_Egfa8tdbqllA:
 
 Call conformance
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_Jr1gUX7Ju4Oh`
 :dt:`Call conformance` measures the compatibility between a set of
 :t:`[argument operand]s` and a set if :t:`[function parameter]s` or
 :t:`[field]s`.
 
-.. _fls_xeo59ol6uh5i:
-
 call expression
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_a9ap0tyk2eou`
 A :dt:`call expression` is an :t:`expression` that invokes a :t:`function` or
 constructs a :t:`tuple struct value` or :t:`tuple enum variant value`.
 
-:dp:`fls_aibti9uqrmmd`
 See :s:`CallExpression`.
-
-.. _fls_ezk9xkst7gfj:
 
 call operand
 ^^^^^^^^^^^^
 
-:dp:`fls_cqnko94y4xbs`
 A :dt:`call operand` is the :t:`function` being invoked or the
 :t:`tuple struct value` or :t:`tuple enum variant value` being constructed by a
 :t:`call expression`.
 
-:dp:`fls_w6wu4wi6srjj`
 See :s:`CallOperand`.
-
-.. _fls_zSh4enFjxeaN:
 
 call resolution
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_fS1ZjGGypvbn`
 :dt:`Call resolution` is a kind of :t:`resolution` that applies to a
 :t:`call expression`.
 
 
-.. _fls_AK8mL1LeftO0:
-
 call site hygiene
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_YTQmXotFOXWU`
 :dt:`Call site hygiene` is a type of :t:`hygiene` which resolves to the
 :s:`MacroInvocation` site. :t:`[Identifier]s` with :t:`call site hygiene` can
 reference the environment of the :s:`MacroRulesDeclaration`, can reference the
 environment of the :s:`MacroInvocation`, and are considered :t:`unhygienic`.
 
-.. _fls_luuc01g4ffog:
-
 callee type
 ^^^^^^^^^^^
 
-:dp:`fls_o21myf6wnnn6`
 A :dt:`callee type` is either a :t:`function item type`, a
 :t:`function pointer type`, a :t:`tuple struct type`, a :t:`tuple enum variant`
 or a :t:`type` that implements any of the :std:`core::ops::Fn`,
 :std:`core::ops::FnMut`, or :std:`core::ops::FnOnce` :t:`[trait]s`.
 
-.. _fls_s78gd8yxx2yv:
-
 capture mode
 ^^^^^^^^^^^^
 
-:dp:`fls_beer0d7wva1d`
 :dt:`Capture mode` is the mechanism by which a :t:`capture target` is captured.
-
-.. _fls_c6qwfwsyizya:
 
 capture target
 ^^^^^^^^^^^^^^
 
-:dp:`fls_xmhcp4x8wblz`
 A :dt:`capture target` is either a :t:`binding` or a :t:`field` of a
 :t:`binding`.
-
-.. _fls_kvu447p6j61k:
 
 capturing
 ^^^^^^^^^
 
-:dp:`fls_4achbk2ewyyb`
 :dt:`Capturing` is the process of saving the :t:`[capture target]s` of a
 :t:`[capturing expression]'s` :t:`capturing environment`.
-
-.. _fls_yfk2xfifltxy:
 
 capturing environment
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7br4azaay3wu`
 The :dt:`capturing environment` of a :t:`capturing expression` consists of all
 :t:`[capture target]s` that are defined outside the :t:`capturing expression`.
-
-.. _fls_cl3lpsfgt5eb:
 
 capturing expression
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_awtny282gtud`
 A :dt:`capturing expression` is either an :t:`async block expression` or a
 :t:`closure expression`.
-
-.. _fls_pcaygpx7db24:
 
 cast
 ^^^^
 
-:dp:`fls_e5hvszhcrtmj`
 :dt:`Cast` or :dt:`casting` is the process of changing the :t:`type` of an
 :t:`expression`.
-
-.. _fls_xl2zlpw070dy:
 
 char
 ^^^^
 
-:dp:`fls_vx0dss1yplw1`
 :dc:`char` is a :t:`type` whose :t:`[value]s` denote :t:`Unicode` characters.
-
-.. _fls_cfphqaml82ik:
 
 character literal
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8oah1cf8p0lb`
 A :dt:`character literal` is a :t:`literal` that denotes a fixed :t:`Unicode`
 character.
 
-:dp:`fls_sup0h5mvibzs`
 See :s:`CharacterLiteral`.
-
-.. _fls_5vm5cijnucsr:
 
 closure body
 ^^^^^^^^^^^^
 
-:dp:`fls_vgnycw6dykwo`
 A :dt:`closure body` is a :t:`construct` that represents the executable portion
 of a :t:`closure expression`.
 
-:dp:`fls_zefhg4auut8d`
 See :s:`ClosureBody`, :s:`ClosureBodyWithReturnType`.
-
-.. _fls_mrwle2ediywb:
 
 closure expression
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_x87rhn9ikz00`
 A :dt:`closure expression` is an :t:`expression` that defines a
 :t:`closure type` and constructs a value of that :t:`type`.
 
-:dp:`fls_psd18dkzplf6`
 See :s:`ClosureExpression`.
-
-.. _fls_f5RBXj9g5iab:
 
 closure parameter
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_yQBZHBLhPswn`
 A :dt:`closure parameter` is a :t:`construct` that yields a set of
 :t:`[binding]s` that bind matched input :t:`[value]s` to :t:`[name]s` at the
 site of a :t:`call expression` or a :t:`method call expression`.
 
-:dp:`fls_Dus3fBU3TwR4`
 See :s:`ClosureParameter`.
-
-.. _fls_xjudl8ykbisi:
 
 closure type
 ^^^^^^^^^^^^
 
-:dp:`fls_wp4kues3nbvn`
 A :dt:`closure type` is a unique anonymous :t:`function type` that encapsulates
 all :t:`[capture target]s` of a :t:`closure expression`.
-
-.. _fls_aqovhozevngd:
 
 code point
 ^^^^^^^^^^
 
-:dp:`fls_6xw8jtiomc2n`
 In :t:`Unicode`, a :dt:`code point` is a numeric :t:`value` that maps to a
 character.
-
-.. _fls_2moavfyeit0m:
 
 comment
 ^^^^^^^
 
-:dp:`fls_3xhoz9f7xy1t`
 A :dt:`comment` is a :t:`lexical element` that acts as an annotation or an
 explanation in program text.
 
-:dp:`fls_pi32rhfqghma`
 See :s:`Comment`.
-
-.. _fls_hjxuoe1hwlhm:
 
 comparison expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_394p7gdruvk7`
 A :dt:`comparison expression` is an :t:`expression` that compares the
 :t:`[value]s` of two :t:`[operand]s`.
 
-:dp:`fls_1jk0s7389mt0`
 See :s:`ComparisonExpression`.
-
-.. _fls_riwule1euzlj:
 
 compilation root
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_stwsfyvov2fx`
 A :dt:`compilation root` is an input to a compilation performed by a tool.
-
-.. _fls_pTMrfPXETibe:
 
 compound assignment
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lGV9QvCmYGcH`
 For :dt:`compound assignment`, see :t:`compound assignment expression`.
-
-.. _fls_iktiir89xbo2:
 
 compound assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mkxpk2jhe5s0`
 A :dt:`compound assignment expression` is an expression that first computes
 a :t:`value` from two :t:`[operand]s` and then assigns the value to an
 :t:`assigned operand`.
 
-:dp:`fls_55abuw8symub`
 See :s:`CompoundAssignmentExpression`.
-
-.. _fls_qyfn5u5cl5l1:
 
 concrete type
 ^^^^^^^^^^^^^
 
-:dp:`fls_l0lr3ybgccjc`
 A :dt:`concrete type` is a :t:`type` described by a :t:`type specification`.
-
-.. _fls_lmacvq89lj2j:
 
 conditional compilation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xymops69eer3`
 :dt:`Conditional compilation` is the process of compiling
 :t:`conditionally-compiled source code`.
-
-.. _fls_bqq013n2cy4t:
 
 conditionally-compiled source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hs4lnrdxpj2g`
 :dt:`Conditionally-compiled source code` is source code that may or may not be
 considered a part of a Rust program depending on certain conditions.
-
-.. _fls_vRjPmHYEVVAf:
 
 configuration predicate
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_TyKIUQMxO9Si`
 A :dt:`configuration predicate` is a :t:`construct` that evaluates statically
 to either ``true`` or ``false``, and controls :t:`conditional compilation`.
 
-:dp:`fls_99ioki0M64fD`
 See :s:`ConfigurationPredicate`.
-
-.. _fls_vuBjK3kdImTn:
 
 const block expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_5ApoJzRSTZGH`
 A :dt:`const block expression` is a :t:`block expression` that is specified
 with :t:`keyword` ``const`` and encapsulates behavior which is evaluated
 statically.
 
-.. _fls_yw57di94gwpf:
-
 constant
 ^^^^^^^^
 
-:dp:`fls_p8rjw2qok85b`
 A :dt:`constant` is an immutable :t:`value` whose uses are substituted by the
 :t:`value`.
 
-:dp:`fls_hlouedpdg1zd`
 See :s:`ConstantDeclaration`.
-
-.. _fls_n7z4cl1fsk6l:
 
 constant argument
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_sz10vgh260xo`
 A :dt:`constant argument` is a :t:`generic argument` that supplies the
 :t:`value` of a :t:`constant parameter`.
 
-:dp:`fls_dz9x6gf3yzc6`
 See :s:`ConstantArgument`.
-
-.. _fls_mtbhv6e9izzm:
 
 constant context
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_9j6mc4i1t73z`
 A :dt:`constant context` is a :t:`construct` that requires a
 :t:`constant expression`.
-
-.. _fls_iofbib2gavnv:
 
 constant expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rmn8w4rh3juf`
 A :dt:`constant expression` is an :t:`expression` that can be evaluated
 statically.
-
-.. _fls_6j1wluj8sku8:
 
 constant function
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_4glkwg11p5ml`
 A :dt:`constant function` is a :t:`function` subject to :t:`keyword` ``const``.
-
-.. _fls_mf022jo05ziu:
 
 constant initializer
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2ge48v1kmw8`
 A :dt:`constant initializer` is a :t:`construct` that provides the :t:`value`
 of its related :t:`constant`.
 
-:dp:`fls_h86eg26z19r2`
 See :s:`ConstantInitializer`.
-
-.. _fls_pj0f0p4avbyw:
 
 constant parameter
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_z7e491m3dx4u`
 A :dt:`constant parameter` is a :t:`generic parameter` for a :t:`constant`.
 
-:dp:`fls_9093wziwxk1g`
 See :s:`ConstantParameter`.
-
-.. _fls_sIvXMhYaZVjD:
 
 constant parameter initializer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_OXD2YaOkfjcI`
 A :dt:`constant parameter initializer` is a :t:`construct` that provides the
 default `:t:`value` of its related :t:`constant parameter`.
 
-:dp:`fls_CMsyUCxGm8Xs`
 See :s:`ConstantParameterInitializer`.
-
-.. _fls_f95c9hrk7t2p:
 
 constant promotion
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ku2md8lnei12`
 :dt:`Constant promotion` is the process of converting a :t:`value expression`
 into a :t:`constant`.
-
-.. _fls_x4niicvxxv9k:
 
 constrain
 ^^^^^^^^^
 
-:dp:`fls_fna0ch8ucyhv`
 A :t:`generic parameter` is said to :dt:`constrain` an :t:`implementation` if
 it makes the :t:`[implementation]'s` applicability more narrow.
-
-.. _fls_4305i29nt5d6:
 
 construct
 ^^^^^^^^^
 
-:dp:`fls_10tvzeo8xex0`
 A :dt:`construct` is a piece of program text that is an instance of a
 :t:`syntactic category`.
-
-.. _fls_fBGjoTVhYvUe:
 
 constructee
 ^^^^^^^^^^^
 
-:dp:`fls_Twbu94uGW4Cb`
 A :dt:`constructee` indicates the :t:`enum variant`, :t:`struct` or :t:`union`
 whose value is being constructed by a :t:`struct expression`.
-
-.. _fls_39s6od9hj4g6:
 
 container operand
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_stjmobac6wyd`
 A :dt:`container operand` is an :t:`operand` that indicates the :t:`value`
 whose :t:`field` is selected in a :t:`field access expression`.
 
-:dp:`fls_hgm1ssicc8j4`
 See :s:`ContainerOperand`.
-
-.. _fls_doazu99vos8x:
 
 continue expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_waxam3m9plfj`
 A :dt:`continue expression` is an :t:`expression` that first terminates and
 then restarts a :t:`loop expression`.
 
-:dp:`fls_smwcz2xw9o1f`
 See :s:`ContinueExpression`.
-
-.. _fls_nC4Knv4tpenW:
 
 control flow boundary
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_SmipZJDp02ij`
 A :dt:`control flow boundary` is a :t:`construct` that limits control flow from
 returning beyond the :t:`construct`, and acts as the target of control flow
 returning operations.
 
-.. _fls_lnwxm6ffy15w:
-
 copy type
 ^^^^^^^^^
 
-:dp:`fls_j7r33ecacyh`
 A :dt:`copy type` is a :t:`type` that implements the
 :std:`core::marker::Copy` :t:`trait`.
-
-.. _fls_kf8yukhxudw8:
 
 crate
 ^^^^^
 
-:dp:`fls_qplsjzb2uyim`
 A :dt:`crate` is a unit of compilation and linking that contains a tree of
 nested :t:`[module]s`.
-
-.. _fls_xwbmmcbbowtu:
 
 crate import
 ^^^^^^^^^^^^
 
-:dp:`fls_y91ja1a87g7a`
 A :dt:`crate import` specifies a dependency on an external :t:`crate`.
 
-:dp:`fls_nmdxagg39hz6`
 See :s:`ExternalCrateImport`.
-
-.. _fls_CXvNvsO10pLL:
 
 crate indication
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_XUSFUErxQRRA`
 A :dt:`crate indication` is a :t:`construct` that indicates a :t:`crate`.
 
-:dp:`fls_s1eFklbzjLxQ`
 See :s:`CrateIndication`.
-
-.. _fls_yf9yjzzhw0rn:
 
 crate public modifier
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_dj7fmrqhbhsv`
 A :dt:`crate public modifier` is a :t:`visibility modifier` that grants a
 :t:`name` :t:`public visibility` within the current :t:`crate` only.
 
-:dp:`fls_wjfupeyeczp0`
 See :s:`CratePublicModifier`.
-
-.. _fls_hv9zyxb72soh:
 
 crate root
 ^^^^^^^^^^
 
-:dp:`fls_yxcgiuybqqy8`
 A :dt:`crate root` is an entry point into a :t:`crate`.
-
-.. _fls_iucxone5ta26:
 
 crate root module
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_oo4nmqv78wno`
 A :dt:`crate root module` is the root of the nested :t:`module` tree of a
 :t:`crate`.
-
-.. _fls_lVpE4uFDsXH4:
 
 crate type
 ^^^^^^^^^^
 
-:dp:`fls_eaxsgPMFNH7f`
 The :dt:`crate type` of a :t:`crate` is the value of the :t:`attribute`
 ``crate_type`` of a :t:`crate` or the value of ``--crate-type`` flag passed to
 the tool compiling the :t:`crate`.
 
-.. _fls_76cj65bptdpn:
-
 dangling
 ^^^^^^^^
 
-:dp:`fls_lq2urzh7bzxx`
 A :t:`value` of an :t:`indirection type` is :dt:`dangling` if it is either
 :c:`null` or not all of the bytes at the referred memory location are part of
 the same allocation.
 
-.. _fls_9meaofgcpvx6:
-
 data race
 ^^^^^^^^^
 
-:dp:`fls_v2s1b57e3r7n`
 A :dt:`data race` is a scenario where two or more threads access a shared
 memory location concurrently.
-
-.. _fls_128iunbbiuql:
 
 decimal literal
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_lwv823lih69m`
 A :dt:`decimal literal` is an :t:`integer literal` in base 10.
 
-:dp:`fls_pxiba4se64y4`
 See :s:`DecimalLiteral`.
-
-.. _fls_9qgy7x6w5ro5:
 
 declaration
 ^^^^^^^^^^^
 
-:dp:`fls_kct7ducpli6k`
 A :dt:`declaration` is a :t:`construct` that introduces a :t:`name` for an
 :t:`entity`.
-
-.. _fls_5944xn0lz8e:
 
 declarative macro
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_pe12lfffaoqt`
 A :dt:`declarative macro` is a :t:`macro` that associates a :t:`name` with a
 set of syntactic transformation rules.
 
-:dp:`fls_1te2kfi9lt6c`
 See :s:`MacroRulesDeclaration`.
-
-.. _fls_GAlaslkO8gLG:
 
 deconstructee
 ^^^^^^^^^^^^^
 
-:dp:`fls_QsvWOdoFWtUO`
 A :dt:`deconstructee` indicates the :t:`enum variant` or :t:`type` that is
 being deconstructed by a :t:`struct pattern`.
 
-:dp:`fls_TkFjmV7AR7lp`
 See :s:`Deconstructee`.
-
-.. _fls_g9v8ubx8m1sq:
 
 default representation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_e85fsp10acnh`
 :dt:`Default representation` is a :t:`type representation` that does not make
 any guarantees about :t:`layout`.
-
-.. _fls_FrfnICpg81sr:
 
 definition site hygiene
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2Y1Dpw5ZEqT3`
 :dt:`Definition site hygiene` is a type of :t:`hygiene` which resolves to the
 :s:`MacroRulesDeclaration` site. :t:`[Identifier]s` with
 :t:`definition site hygiene` cannot reference the environment of the
 :s:`MacroRulesDeclaration`, cannot be referenced by the environment of a
 :s:`MacroInvocation`, and are considered :t:`hygienic`.
 
-.. _fls_127n1n5ssk2b:
-
 dereference
 ^^^^^^^^^^^
 
-:dp:`fls_hk97pb1qt04y`
 A :dt:`dereference` is the memory location produced by evaluating a
 :t:`dereference expression`.
-
-.. _fls_o588wfq878rm:
 
 dereference expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_3cuyhbh2llei`
 A :dt:`dereference expression` is an :t:`expression` that obtains the
 pointed-to memory location of its :t:`operand`.
 
-:dp:`fls_hx0jwahdb1nf`
 See :s:`DereferenceExpression`.
-
-.. _fls_xbN0GtcH8emc:
 
 dereference type
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_HfuUQ7IaoI5j`
 A :dt:`dereference type` is either a :t:`reference type` or a :t:`type` that
 implements the :std:`core::ops::Deref` :t:`trait`.
-
-.. _fls_T380NdEsFxIp:
 
 dereference type chain
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_kIzoAEf069HE`
 A :dt:`dereference type chain` is a sequence of :t:`[dereference type]s`.
-
-.. _fls_7ipdj78o7ln:
 
 derive macro
 ^^^^^^^^^^^^
 
-:dp:`fls_jrrjhl9hocrm`
 A :dt:`derive macro` is a :t:`procedural macro` that consumes a stream of
 :t:`[token]s` and produces a stream of tokens, and is invoked via attribute
 :c:`derive`.
 
-.. _fls_7b3fsp356e9l:
-
 destruction
 ^^^^^^^^^^^
 
-:dp:`fls_58i2nfhxze3j`
 :dt:`Destruction` is the process of recovering resources associated with a
 :t:`value` as it goes out of scope.
-
-.. _fls_kwxpy451gtc:
 
 destructor
 ^^^^^^^^^^
 
-:dp:`fls_79pp7o1xooja`
 A :dt:`destructor` is a :t:`function` that is invoked immediately before the
 :t:`destruction` of a :t:`value` of a :t:`drop type`.
-
-.. _fls_2fuu3zr9rn2q:
 
 destructuring assignment
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7jienn9uzn5k`
 A :dt:`destructuring assignment` is an :t:`assignment expression` where
 the :t:`assignee operand` is either an :t:`array expression`, a
 :t:`struct expression`, or a :t:`tuple expression`.
 
-.. _fls_ugIFZlAzDK6H:
-
 direction modifier
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8DY7xPVX4nXx`
 A :dt:`direction modifier` is a :t:`construct` that indicates whether a
 :t:`register argument` initializes a :t:`register`, assigns the :t:`value` of a
 :t:`register` to an :t:`expression`, or both.
 
-:dp:`fls_lRKEzY3fQ3B2`
 See :s:`DirectionModifier`.
-
-.. _fls_7vg56eeo0zlg:
 
 discriminant
 ^^^^^^^^^^^^
 
-:dp:`fls_dfegy9y6awx`
 A :dt:`discriminant` is an opaque integer that identifies an :t:`enum variant`.
-
-.. _fls_xayj37ocbqjn:
 
 discriminant initializer
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_o7hihgcqmnyc`
 A :dt:`discriminant initializer` provides the :t:`value` of a :t:`discriminant`.
 
-:dp:`fls_g5obc23vigng`
 See :s:`DiscriminantInitializer`.
-
-.. _fls_a0ezuPLtENme:
 
 discriminant type
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_kqdvWGi9cglm`
 A :dt:`discriminant type` is the :t:`type` of a :t:`discriminant`.
-
-.. _fls_gDFsAj1Bvx7A:
 
 diverging expression
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_fLlNzmB34cj9`
 A :dt:`diverging expression` is an :t:`expression` whose :t:`evaluation` causes
 program flow to diverge from the normal :t:`evaluation` order.
-
-.. _fls_9DuaIn6cRbXf:
 
 diverging type variable
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_sxyL7yOp3H9s`
 A :dt:`diverging type variable` is a :t:`type variable` that can refer to any
 :t:`type` and originates from a :t:`diverging expression`.
-
-.. _fls_0lpT9Ncj7S9X:
 
 division assignment
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_kvQskrzE1y97`
 For :dt:`division assignment`, see :t:`division assignment expression`.
-
-.. _fls_ccv27fji08ou:
 
 division assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lzuz5fkveikk`
 A :dt:`division assignment expression` is a :t:`compound assignment expression`
 that uses division.
 
-:dp:`fls_cdxt76aqwtkq`
 See :s:`DivisionAssignmentExpression`.
-
-.. _fls_vxd5q8nekkn0:
 
 division expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_du05yp205f4y`
 A :dt:`division expression` is an :t:`arithmetic expression` that uses division.
 
-:dp:`fls_d3vwk4autyd`
 See :s:`DivisionExpression`.
-
-.. _fls_4nm1r57ntecm:
 
 doc comment
 ^^^^^^^^^^^
 
-:dp:`fls_wkc1w2xk7ebh`
 A :dt:`doc comment` is a :t:`comment` class that includes
 :t:`[inner block doc]s`, :t:`[inner line doc]s`, :t:`[outer block doc]s`,
 and :t:`[outer line doc]s`.
 
-.. _fls_nw0qr4xy3zxq:
-
 drop construct
 ^^^^^^^^^^^^^^
 
-:dp:`fls_odg2asgj28m`
 A :dt:`drop construct` is a :t:`construct` that employs a :t:`drop scope`.
-
-.. _fls_j12e358828h:
 
 drop order
 ^^^^^^^^^^
 
-:dp:`fls_qddkiabu6swt`
 :dt:`Drop order` is the order by which :t:`[value]s` are :t:`dropped` when a
 :t:`drop scope` is left.
-
-.. _fls_foszri7hdym0:
 
 drop scope
 ^^^^^^^^^^
 
-:dp:`fls_6bu8x0g9q0er`
 A :dt:`drop scope` is a region of program text that governs the :t:`dropping`
 of :t:`[value]s`.
-
-.. _fls_qp3ksd2lxm8:
 
 drop scope extension
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_pmdh8kkrwkd0`
 :dt:`Drop scope extension` is the process of extending a :t:`drop scope`
 associated with a :t:`temporary` to prevent the premature :t:`dropping` of the
 :t:`temporary`.
 
-.. _fls_4v6vsuw4g89l:
-
 drop type
 ^^^^^^^^^
 
-:dp:`fls_ot3e31kwixil`
 A :dt:`drop type` is a :t:`type` that implements the :std:`core::ops::Drop`
 :t:`trait` or contains a :t:`field` that has a :t:`destructor`.
-
-.. _fls_68cl4paduzx2:
 
 dropping
 ^^^^^^^^
 
-:dp:`fls_k4mguykh8ey`
 :dt:`Dropping` a :t:`value` is the act of invoking the :t:`destructor` of the
 related :t:`type`.
-
-.. _fls_6uovyjjzh6km:
 
 dynamically sized type
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_eeyxu730z2pw`
 A :dt:`dynamically sized type` is a :t:`type` that does not implement the
 :std:`core::marker::Sized` :t:`trait`.
-
-.. _fls_2sja3okj27ne:
 
 elaboration
 ^^^^^^^^^^^
 
-:dp:`fls_xoahzmwu1std`
 :dt:`Elaboration` is the process by which a :t:`declaration` achieves its
 runtime effects.
-
-.. _fls_bxm4njfo2h58:
 
 element type
 ^^^^^^^^^^^^
 
-:dp:`fls_3bndijf8g9os`
 An :dt:`element type` is the :t:`type` of the elements of an :t:`array type` or
 a :t:`slice type`.
 
-:dp:`fls_pvyl887dn016`
 See :s:`ElementType`.
-
-.. _fls_vygjg858yxej:
 
 elided
 ^^^^^^
 
-:dp:`fls_lo3c3n9wy6qz`
 For :dt:`elided`, see :t:`elided lifetime`.
-
-.. _fls_l2181y5566ck:
 
 elided lifetime
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_9q28407ev0a6`
 An :dt:`elided lifetime` is either an :t:`unnamed lifetime` or a :t:`lifetime`
 that has been explicitly omitted from a :t:`function signature` or an
 :t:`implementation`.
 
-.. _fls_ff5zp7m9d5ot:
-
 else expression
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_inp7luoqkjc5`
 An :dt:`else expression` is an :t:`expression` that represents either a
 :t:`block expression`, an :t:`if expression`, or an :t:`if let expression`.
 
-:dp:`fls_2jniy6bkq1hn`
 See :s:`ElseExpression`.
-
-.. _fls_iwed9n4jz6b8:
 
 empty statement
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_irw5gwuvj3nn`
 An :dt:`empty statement` is a :t:`statement` expressed as character 0x3B
 (semicolon).
-
-.. _fls_1qu1t74ga8aa:
 
 entity
 ^^^^^^
 
-:dp:`fls_mdbck557k8sy`
 An :dt:`entity` is a :t:`construct` that can be referred to within program
 text, usually via a :t:`field access expression` or a :t:`path`.
-
-.. _fls_xnhj9fqlfs2p:
 
 enum
 ^^^^
 
-:dp:`fls_9o0ig19xh2f5`
 An :dt:`enum` is an :t:`item` that declares an :t:`enum type`.
-
-.. _fls_zrRydWZgm03k:
 
 enum field
 ^^^^^^^^^^
 
-:dp:`fls_J8udq05QGiEj`
 An :dt:`enum field` is a :t:`field` of an :t:`enum variant`.
-
-.. _fls_grlluqa4ucp3:
 
 enum type
 ^^^^^^^^^
 
-:dp:`fls_idwrgo87ub3i`
 An :dt:`enum type` is an :t:`abstract data type` that contains
 :t:`[enum variant]s`.
 
-:dp:`fls_o6ih6n1z1566`
 See :s:`EnumDeclaration`.
-
-.. _fls_H6aUAUjNlx6z:
 
 enum value
 ^^^^^^^^^^
 
-:dp:`fls_QdBTdVLB2xHk`
 An :dt:`enum value` is a :t:`value` of an :t:`enum type`.
-
-.. _fls_klwlx5jixwud:
 
 enum variant
 ^^^^^^^^^^^^
 
-:dp:`fls_9jq4keg9y94u`
 An :dt:`enum variant` is a :t:`construct` that declares one of the
 possible variations of an :t:`enum`.
 
-:dp:`fls_tj2s55onen6b`
 See :s:`EnumVariant`.
-
-.. _fls_mKxBWCojhnWu:
 
 enum variant value
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_VQRqNPFFWmDp`
 An :dt:`enum variant value` is the :t:`enum value` of the corresponding
 :t:`enum` of the :t:`enum variant`.
-
-.. _fls_alifv570nx7q:
 
 equals expression
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mn1g2hijtd6f`
 An :dt:`equals expression` is a :t:`comparison expression` that tests equality.
 
-:dp:`fls_j32l4do0xw4d`
 See :s:`EqualsExpression`.
-
-.. _fls_kz7tgpi8xkt4:
 
 error propagation expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_5kebgodxtqqt`
 An :dt:`error propagation expression` is an :t:`expression` that either
 evaluates to a :t:`value` of its :t:`operand` or returns a value to the next
 control flow boundary.
 
-:dp:`fls_agyqvyda3rcj`
 See :s:`ErrorPropagationExpression`.
-
-.. _fls_9hw559b548m0:
 
 escaped character
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7yvnbakmo7y5`
 An :dt:`escaped character` is the textual representation for a character with
 special meaning. An escaped character consists of character 0x5C (reverse
 solidus), followed by the single character encoding of the special meaning
 character. For example, ``\t`` is the escaped character for 0x09 (horizontal
 tabulation).
 
-.. _fls_pefe9ng1mm81:
-
 evaluated
 ^^^^^^^^^
 
-:dp:`fls_769tm6hn9g5e`
 See :t:`evaluation`.
-
-.. _fls_p3gre0895k2u:
 
 evaluation
 ^^^^^^^^^^
 
-:dp:`fls_8zmtio6razl1`
 :dt:`Evaluation` is the process by which an :t:`expression` achieves its
 runtime effects.
-
-.. _fls_EJSzYb4IxvtR:
 
 exclusive range pattern
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_qxsV6ZxFfDHm`
 An :dt:`exclusive range pattern` is a :t:`range pattern` with both a
 :t:`range pattern low bound` and a :t:`range pattern high bound`.
 
-:dp:`fls_kHIWYUPhxikM`
 See :s:`ExclusiveRangePattern`.
-
-.. _fls_nw0eg7gwayrg:
 
 executed
 ^^^^^^^^
 
-:dp:`fls_kelmsc68lyf7`
 See :t:`execution`.
-
-.. _fls_q0ur239s8uv:
 
 execution
 ^^^^^^^^^
 
-:dp:`fls_e5jbii84hd5g`
 :dt:`Execution` is the process by which a :t:`statement` achieves its runtime
 effects.
-
-.. _fls_B1qkkSvc69J4:
 
 explicit register argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2o6S1WGDrMh3`
 An :dt:`explicit register argument` is a :t:`register argument` that uses an
 :t:`explicit register name`.
-
-.. _fls_uc7PnSbVVd9X:
 
 explicit register name
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_UcMk6RRLrkB5`
 An :dt:`explicit register name` is a target-specific string that identifies
 a :t:`register`.
 
-:dp:`fls_Z3WDh75VpSUU`
 See :s:`ExplicitRegisterName`.
-
-.. _fls_lqxcnZqvwcsH:
 
 explicitly declared entity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_shpNJ0JCSCwa`
 An :dt:`explicitly declared entity` is an :t:`entity` that has a
 :t:`declaration`.
-
-.. _fls_5oQllRM7Wjsg:
 
 exported function
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_QotMF1iaEYod`
 An :dt:`exported function` is an export of a :t:`function`.
-
-.. _fls_zkq5ZkJwsyoD:
 
 exported static
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_aolCSvb349ZU`
 An :dt:`exported static` is an export of a :t:`static`.
-
-.. _fls_q8ofwncggngd:
 
 expression
 ^^^^^^^^^^
 
-:dp:`fls_f7iuwgbs1lql`
 An :dt:`expression` is a :t:`construct` that produces a :t:`value`, and may
 have side effects at run-time.
 
-:dp:`fls_8l9hru1x586q`
 See :s:`Expression`.
-
-.. _fls_a1rorkjt3vpc:
 
 expression statement
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ds0pspiqk4am`
 An :dt:`expression statement` is an :t:`expression` whose result is ignored.
 
-:dp:`fls_41jt1h3audzv`
 See :s:`ExpressionStatement`.
-
-.. _fls_u6huewic8650:
 
 expression-with-block
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ujlm50le5dnj`
 An :dt:`expression-with-block` is an :t:`expression` whose structure involves a
 :t:`block expression`.
 
-:dp:`fls_iwheys965ml3`
 See :s:`ExpressionWithBlock`.
-
-.. _fls_378e2xhxzk26:
 
 expression-without-block
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xfh9xmsphzqb`
 An :dt:`expression-without-block` is an :t:`expression` whose structure does
 not involve a :t:`block expression`.
 
-:dp:`fls_miaphjnikd51`
 See :s:`ExpressionWithoutBlock`.
-
-.. _fls_9k6jcsljghab:
 
 external block
 ^^^^^^^^^^^^^^
 
-:dp:`fls_z2ebcp7kjpuy`
 An :dt:`external block` is a :t:`construct` that provides the declarations of
 foreign :t:`[function]s` as unchecked imports.
 
-:dp:`fls_dm2wz1th2haz`
 See :s:`ExternalBlock`.
-
-.. _fls_8ffbgzkbsf9r:
 
 external function
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ngz5fqwrf86e`
 An :dt:`external function` is an unchecked import of a foreign :t:`function`.
-
-.. _fls_ug2kags0o6is:
 
 external function item type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_dwlovqly44dj`
 An :dt:`external function item type` is a :t:`function item type` where the
 related :t:`function` is an :t:`external function`.
-
-.. _fls_c89migfc2m6e:
 
 external static
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_bqq6cncstzeg`
 An :dt:`external static` is an import of a foreign :t:`variable`.
-
-.. _fls_4w6garmjhrd9:
 
 f32
 ^^^
 
-:dp:`fls_4w5rqj7zdemu`
 :dc:`f32` is a :t:`floating-point type` equivalent to the IEEE 754-2008
 binary32 :t:`type`.
-
-.. _fls_pj450h99yo28:
 
 f64
 ^^^
 
-:dp:`fls_ly6p0i6lsibh`
 :dc:`f64` is a :t:`floating-point type` equivalent to the IEEE 754-2008
 binary64 :t:`type`.
-
-.. _fls_nkf9z4pqg8x1:
 
 fat pointer
 ^^^^^^^^^^^
 
-:dp:`fls_knbc2jv5c5ds`
 A :dt:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
-
-.. _fls_trvkbidlsss8:
 
 fat pointer type
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_l8ew6udd79hh`
 A :dt:`fat pointer type` is an :t:`indirection type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
-
-.. _fls_qi21fdknzez6:
 
 FFI
 ^^^
 
-:dp:`fls_z363fu89mj1c`
 For :dt:`FFI`, see :t:`Foreign Function Interface`.
-
-.. _fls_7gCAbHnGEIl6:
 
 field
 ^^^^^
 
-:dp:`fls_uAkrgfFTK2YV`
 A :dt:`field` is an element of an :t:`abstract data type`.
-
-.. _fls_yipl7ajrbs6y:
 
 field access expression
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_gdl348a04d15`
 A :dt:`field access expression` is an :t:`expression` that accesses a
 :t:`field` of a :t:`value`.
 
-:dp:`fls_luetyuwu54d6`
 See :s:`FieldAccessExpression`.
-
-.. _fls_6uwwat9j4x7y:
 
 field index
 ^^^^^^^^^^^
 
-:dp:`fls_6061r871qgbj`
 A :dt:`field index` is the position of a :t:`field` within a
 :t:`tuple struct type` or :t:`tuple enum variant`. The first :t:`field` has a
 :t:`field index` of zero, the Nth :t:`field` has a :t:`field index` of N-1.
 
-:dp:`fls_IDYKXUIL845x`
 See :s:`FieldIndex`.
-
-.. _fls_8qLL14WfXXNN:
 
 field list
 ^^^^^^^^^^
 
-:dp:`fls_xMZsrxMc9Cni`
 A :dt:`field list` is a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
-
-.. _fls_BlZwxp6H62sS:
 
 field resolution
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_nL8UuclgxfGL`
 :dt:`Field resolution` is a form of :t:`resolution` that applies to a
 :t:`field access expression`.
-
-.. _fls_kqbata8slp1y:
 
 field selector
 ^^^^^^^^^^^^^^
 
-:dp:`fls_aq1yg9cp1uof`
 A :dt:`field selector` is a :t:`construct` that selects the :t:`field` to be
 accessed in a :t:`field access expression`.
 
-:dp:`fls_x8swot8e1j32`
 See :s:`FieldSelector`.
-
-.. _fls_mj9mmkar8c6f:
 
 final match arm
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_btoz8jioisx9`
 A :dt:`final match arm` is the last :t:`match arm` of a :t:`match expression`.
 
-:dp:`fls_v7ockjwbeel1`
 See :s:`FinalMatchArm`.
-
-.. _fls_rljxa45tleq3:
 
 fixed sized type
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_eadiywl20jo4`
 A :dt:`fixed sized type` is a :t:`type` that implements the
 :std:`core::marker::Sized` :t:`trait`.
-
-.. _fls_achdyw3nbme3:
 
 float literal
 ^^^^^^^^^^^^^
 
-:dp:`fls_53o8dio9vpjh`
 A :dt:`float literal` is a :t:`numeric literal` that denotes a fractional
 number.
 
-:dp:`fls_hqeaakhsqxok`
 See :s:`FloatLiteral`.
-
-.. _fls_wgylj1n4wrqe:
 
 float suffix
 ^^^^^^^^^^^^
 
-:dp:`fls_vka2z7frq9j8`
 A :dt:`float suffix` is a component of a :t:`float literal` that specifies an
 explicit :t:`floating-point type`.
 
-:dp:`fls_2k1ddqhsgxqk`
 See :s:`FloatSuffix`.
-
-.. _fls_k32g8cd9friu:
 
 floating-point type
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_1w5yjiffah1u`
 A :dt:`floating-point type` is a :t:`numeric type` whose :t:`[value]s` denote
 fractional numbers.
-
-.. _fls_8ih3gh6hoy78:
 
 floating-point type variable
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ls41emhkrxdi`
 A :dt:`floating-point type variable` is a :t:`type variable` that can refer
 only to :t:`[floating-point type]s`.
-
-.. _fls_nE6SWuVH7X68:
 
 floating-point value
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rx8cvWPlvel5`
 A :dt:`floating-point value` is a :t:`value` of a :t:`floating-point type`.
-
-.. _fls_dwnvkq8n94h1:
 
 for loop
 ^^^^^^^^
 
-:dp:`fls_gmhh56arsbw8`
 For :dt:`for loop`, see :t:`for loop expression`.
-
-.. _fls_vfkqbovqbw86:
 
 for loop expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_f0gp7qxoc4o4`
 A :dt:`for loop expression` is a :t:`loop expression` that continues to
 evaluate its :t:`loop body` as long as its :t:`subject expression` yields a
 :t:`value`.
 
-:dp:`fls_yn4d35pvmn87`
 See :s:`ForLoopExpression`.
-
-.. _fls_fo7vyxs4l3yh:
 
 Foreign Function Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_240yj1kym1kh`
 :dt:`Foreign Function Interface` employs :t:`ABI`, :t:`[attribute]s`,
 :t:`external block`, :t:`[external function]s`, linkage, and :t:`type`
 :t:`layout` to interface a Rust program with foreign code.
 
-.. _fls_pi7j0t7h1y86:
-
 fragment specifier
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6lhwep7ulpr0`
 A :dt:`fragment specifier` is a :t:`construct` that indicates the :t:`type` of
 a :t:`metavariable`.
 
-:dp:`fls_drfn9yqrihgx`
 See ``MacroFragmentSpecifier``.
-
-.. _fls_tWp1PLe8m83K:
 
 full range expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_NIb9UOIRjMqa`
 A :dt:`full range expression` is a :t:`range expression` that covers the full
 range of a :t:`type`.
-
-.. _fls_yllg093syzdi:
 
 function
 ^^^^^^^^
 
-:dp:`fls_ni14pcm4ap9l`
 A :dt:`function` is a :t:`value` of a :t:`function type` that models a behavior.
 
-:dp:`fls_hn01vvw2fx9m`
 See :s:`FunctionDeclaration`.
-
-.. _fls_vjgkg8kfi93:
 
 function body
 ^^^^^^^^^^^^^
 
-:dp:`fls_y5ha4123alik`
 A :dt:`function body` is the :t:`block expression` of a :t:`function`.
 
-:dp:`fls_r0g0i730x6x4`
 See :s:`FunctionBody`.
-
-.. _fls_ayuia853po0a:
 
 function item type
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rfvfo8x42dh8`
 A :dt:`function item type` is a unique anonymous :t:`function type` that
 identifies a :t:`function`.
-
-.. _fls_WMaE58yv1joW:
 
 function lifetime elision
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tZMmRHua1S8K`
 :dt:`Function lifetime elision` is a form of :t:`lifetime elision` that applies
 to :t:`[function]s`, :t:`[function pointer type parameter]s` and :t:`[path]s`
 resolving to one of the :std:`core::ops::Fn`, :std:`core::ops::FnMut`, and
 :std:`core::ops::FnOnce` :t:`[trait]s`.
 
-.. _fls_xn800gcjnln1:
-
 function parameter
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2feq1ky9pla1`
 A :dt:`function parameter` is a :t:`construct` that yields a set of
 :t:`[binding]s` that bind matched input :t:`[value]s` to :t:`[name]s` at the
 site of a :t:`call expression` or a :t:`method call expression`.
 
-:dp:`fls_4tf20svi3rjx`
 See :s:`FunctionParameter`.
-
-.. _fls_fqwzlg78k503:
 
 function pointer type
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lcawg25xhblx`
 A :dt:`function pointer type` is an :t:`indirection type` that refers to a
 :t:`function`.
 
-:dp:`fls_t50umpk5abjy`
 See :s:`FunctionPointerTypeSpecification`.
-
-.. _fls_v3V6K4S5UhIF:
 
 function pointer type parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_nF1k90JJWq2K`
 A :dt:`function pointer type parameter` is a :t:`function parameter` of a
 :t:`function pointer type`.
 
-:dp:`fls_vvy6qogy0xnb`
 See :s:`FunctionPointerTypeParameter`.
-
-.. _fls_2uvom1x42dcs:
 
 function qualifier
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8cux22275v8r`
 A :dt:`function qualifier` is a :t:`construct` that determines the role of
 a :t:`function`.
 
-:dp:`fls_3td9tztnj2jq`
 See :s:`FunctionQualifierList`.
-
-.. _fls_hz3zunp8lrfl:
 
 function signature
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ndld48kg6o8d`
 A :dt:`function signature` is a unique identification of a :t:`function`
 that encompasses of its :t:`[function qualifier]s`, :t:`name`,
 :t:`[generic parameter]s`, :t:`[function parameter]s`, :t:`return type`, and
 :t:`where clause`.
 
-.. _fls_yo2x1llt9ejy:
-
 function type
 ^^^^^^^^^^^^^
 
-:dp:`fls_4e19116glgtv`
 A :dt:`function type` is either a :t:`closure type` or a
 :t:`function item type`.
-
-.. _fls_gzybxk1gosm6:
 
 function-like macro
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_psnab9cuq4bu`
 A :dt:`function-like macro` is a :t:`procedural macro` that consumes a stream
 of :t:`[token]s` and produces a stream of tokens, and is invoked directly.
-
-.. _fls_OFMoUA3eFtuC:
 
 fundamental
 ^^^^^^^^^^^
 
-:dp:`fls_e0dRD4NTE0UP`
 A :t:`trait` or :t:`type` is :dt:`fundamental` when its
 :t:`implementation coherence` rules are relaxed and the :t:`trait` or :t:`type`
 is always treated as if it was a :t:`local trait` or a :t:`local type`.
 
-.. _fls_yxzpexco8ag3:
-
 future
 ^^^^^^
 
-:dp:`fls_pvigospl4n3g`
 A :dt:`future` represents a :t:`value` of a :t:`type` that implements the
 :std:`core::future::Future` :t:`trait` which may not have finished computing
 yet.
 
-.. _fls_dvk8ccb46abk:
-
 future operand
 ^^^^^^^^^^^^^^
 
-:dp:`fls_fold1inh5jev`
 A :dt:`future operand` is an :t:`operand` whose :t:`future` is being awaited by
 an :t:`await expression`.
 
-:dp:`fls_tbfpowv90u5w`
 See :s:`FutureOperand`.
-
-.. _fls_j1cyhud0h65t:
 
 generic argument
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_meimxi20p51a`
 A :dt:`generic argument` supplies a static input for an
 :t:`associated trait type` or a :t:`generic parameter`.
 
-:dp:`fls_8bvdmdgbu17l`
 See :s:`GenericArgumentList`.
-
-.. _fls_nooYIxMnV8Ps:
 
 generic associated type
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_O4wckPZPmree`
 A :dt:`generic associated type` is an :t:`associated type` with
 :t:`[generic parameter]s`.
-
-.. _fls_3uFg0NK5fYQ6:
 
 generic conformance
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_PfvELNsNySLT`
 :dt:`Generic conformance` measures the compatibility between a set of
 :t:`[generic parameter]s` and a set of :t:`[generic argument]s`.
-
-.. _fls_3tj3i83eoi36:
 
 generic enum
 ^^^^^^^^^^^^
 
-:dp:`fls_pnu8w26uexaq`
 A :dt:`generic enum` is an :t:`enum` with :t:`[generic parameter]s`.
-
-.. _fls_votx8gvy5utg:
 
 generic function
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_rfkbc967d48h`
 A :dt:`generic function` is a :t:`function` with :t:`[generic parameter]s`.
-
-.. _fls_1xjbrp376niw:
 
 generic implementation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_jic937ujpnar`
 A :dt:`generic implementation` is an :t:`implementation` with
 :t:`[generic parameter]s`.
-
-.. _fls_s2syghgn74e2:
 
 generic parameter
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_61e6br8jy1v2`
 A :dt:`generic parameter` is a placeholder for a :t:`constant`, a
 :t:`lifetime`, or a :t:`type` whose :t:`value` is supplied statically by a
 :t:`generic argument`.
 
-:dp:`fls_jvxpoob39632`
 See :s:`GenericParameterList`.
-
-.. _fls_CzudKdaYbfBF:
 
 generic parameter scope
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_e2tICijmLkj4`
 A :dt:`generic parameter scope` is a :t:`scope` for :t:`[generic parameter]s`.
-
-.. _fls_cgtu4v2vxvh:
 
 generic struct
 ^^^^^^^^^^^^^^
 
-:dp:`fls_mcb2mlklith8`
 A :dt:`generic struct` is a :t:`struct` with :t:`[generic parameter]s`.
-
-.. _fls_VBEBshUrAOKE:
 
 generic substitution
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Led1Nxfcd70K`
 A :dt:`generic substitution` is the replacement of a :t:`generic parameter`
 with a :t:`generic argument`.
-
-.. _fls_hppo1v3ia4wu:
 
 generic trait
 ^^^^^^^^^^^^^
 
-:dp:`fls_h515f11akr91`
 A :dt:`generic trait` is a :t:`trait` with :t:`[generic parameter]s`.
-
-.. _fls_3Ss6jDgtF1of:
 
 generic type
 ^^^^^^^^^^^^
 
-:dp:`fls_Zn2pIsMZoTry`
 A :dt:`generic type` is a :t:`type` with a :t:`generic parameter`.
-
-.. _fls_18ow0q8at1pi:
 
 generic type alias
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_zgxsqq4vu7e3`
 A :dt:`generic type alias` is a :t:`type alias` with :t:`[generic parameter]s`.
-
-.. _fls_xn9mla1vm6iv:
 
 generic union
 ^^^^^^^^^^^^^
 
-:dp:`fls_93rxr0yjx1e7`
 A :dt:`generic union` is a :t:`union` with :t:`[generic parameter]s`.
-
-.. _fls_euukteybsbi:
 
 glob import
 ^^^^^^^^^^^
 
-:dp:`fls_90qsib7g8e9j`
 A :dt:`glob import` is a :t:`use import` that brings all :t:`[name]s` with
 :t:`public visibility` prefixed by its :t:`path` prefix into :t:`scope`.
 
-:dp:`fls_n4plc55cij0j`
 See :s:`GlobImport`.
-
-.. _fls_g6g8c58bilen:
 
 global path
 ^^^^^^^^^^^
 
-:dp:`fls_msg8jw9momfw`
 A :dt:`global path` is a :t:`path` that starts with :t:`namespace qualifier`
 ``::``.
-
-.. _fls_hy1clqvaewnp:
 
 global type variable
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_pvt4nayq006s`
 A :dt:`global type variable` is a :t:`type variable` that can refer to any
 :t:`type`.
-
-.. _fls_g4n20dy3utzy:
 
 greater-than expression
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_j7x5qii6rhwj`
 A :dt:`greater-than expression` is a :t:`comparison expression` that tests for
 a greater-than relationship.
 
-:dp:`fls_yni50ba3ufvs`
 See :s:`GreaterThanExpression`.
-
-.. _fls_mxz589rq4hiy:
 
 greater-than-or-equals expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wvspqc2otn6v`
 A :dt:`greater-than-or-equals expression` is a :t:`comparison expression` that
 tests for a greater-than-or-equals relationship.
 
-:dp:`fls_9azbvj9xux6y`
 See :s:`GreaterThanOrEqualsExpression`.
-
-.. _fls_fquvoglio1jz:
 
 half-open range pattern
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tymjispfgp7u`
 A :dt:`half-open range pattern` is a :t:`range pattern` with only a
 :t:`range pattern low bound`.
 
-:dp:`fls_evm3nxwswk00`
 See :s:`HalfOpenRangePattern`.
-
-.. _fls_5uiij8eqln5g:
 
 hexadecimal literal
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8b6njsi8g68i`
 A :dt:`hexadecimal literal` is an :t:`integer literal` in base 16.
 
-:dp:`fls_vssa4z5wcgaa`
 See :s:`HexadecimalLiteral`.
-
-.. _fls_h87i5nbeuxky:
 
 higher-ranked trait bound
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lpyc4omcthv`
 A :dt:`higher-ranked trait bound` is a :t:`bound` that specifies an infinite
 list of :t:`[bound]s` for all possible :t:`[lifetime]s`.
 
-:dp:`fls_m3nrsdvxxg6j`
 See :s:`ForGenericParameterList`.
-
-.. _fls_GuMMjhEMMLvF:
 
 hygiene
 ^^^^^^^
 
-:dp:`fls_AQg0MqAQZqkz`
 :dt:`Hygiene` is a property of :t:`[macro]s` and :t:`[identifier]s`` that
 appear within them, which aims to eliminate the syntactic interference between
 a :t:`macro` and its environment.
 
-.. _fls_95h0aWZ7xx6U:
-
 hygienic
 ^^^^^^^^
 
-:dp:`fls_hiDddAkNH5Ms`
 An :t:`identifier` is :dt:`hygienic` when it has :t:`definition site hygiene`.
-
-.. _fls_obiv2a6ywfhh:
 
 i8
 ^^
 
-:dp:`fls_1y9ulxnz8qba`
 :dc:`i8` is a :t:`signed integer type` whose :t:`[value]s` range from - (2\
 :sup:`7`) to 2\ :sup:`7` - 1, all inclusive.
-
-.. _fls_rvcjp656gzlm:
 
 i16
 ^^^
 
-:dp:`fls_ci9jl55wxwdg`
 :dc:`i16` is a :t:`signed integer type` whose :t:`[value]s` range from - (2\
 :sup:`15`) to 2\ :sup:`15` - 1, all inclusive.
-
-.. _fls_l1h9g4ntf3c:
 
 i32
 ^^^
 
-:dp:`fls_yh8wzhhso4xc`
 :dc:`i32` is a :t:`signed integer type` whose :t:`[value]s` range from - (2\
 :sup:`31`) to 2\ :sup:`31` - 1, all inclusive.
-
-.. _fls_tid10guzn9sq:
 
 i64
 ^^^
 
-:dp:`fls_4bpatxp8yelv`
 :dc:`i64` is a :t:`signed integer type` whose :t:`[value]s` range from - (2\
 :sup:`63`) to 2\ :sup:`63` - 1, all inclusive.
-
-.. _fls_py2whbcrndmz:
 
 i128
 ^^^^
 
-:dp:`fls_p75kpbtonb8z`
 :dc:`i128` is a :t:`signed integer type` whose :t:`[value]s` range from - (2\
 :sup:`127`) to 2\ :sup:`127` - 1, all inclusive.
-
-.. _fls_kpsyz8yopova:
 
 identifier
 ^^^^^^^^^^
 
-:dp:`fls_14zc5bcm9d8o`
 An :dt:`identifier` is a :t:`lexical element` that refers to a :t:`name`.
 
-:dp:`fls_oddu2wzhczvq`
 See :s:`Identifier`.
-
-.. _fls_1g9xxx8s498u:
 
 identifier pattern
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_f2va67gvpqe0`
 An :dt:`identifier pattern` is a :t:`pattern` that binds the :t:`value` it
 matches to a :t:`binding`.
 
-:dp:`fls_nxa1gvqgitgk`
 See :s:`IdentifierPattern`.
-
-.. _fls_al9gtcy5b5og:
 
 if expression
 ^^^^^^^^^^^^^
 
-:dp:`fls_rk0661mtdvsi`
 An :dt:`if expression` is an :t:`expression` that evaluates either a
 :t:`block expression` or an :t:`else expression` depending on the :t:`value`
 of its :t:`subject expression`.
 
-:dp:`fls_gdsufx2ns8bl`
 See :s:`IfExpression`.
-
-.. _fls_j9wb2wtqp5u8:
 
 if let expression
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ky6ng7jy1g6z`
 An :dt:`if let expression` is an :t:`expression` that evaluates either a
 :t:`block expression` or an :t:`else expression` depending on whether its
 :t:`pattern` can be matched against its :t:`subject let expression`.
 
-:dp:`fls_kczg3c6n3psu`
 See :s:`IfLetExpression`.
-
-.. _fls_xiocbknerufq:
 
 immutable
 ^^^^^^^^^
 
-:dp:`fls_sttdfynyqr5h`
 A :t:`value` is :dt:`immutable` when it cannot be modified.
-
-.. _fls_utucrvtzjhoc:
 
 immutable borrow
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_p0abqkiuk7y9`
 An :dt:`immutable borrow` is an :t:`immutable reference` produced by
 :t:`borrowing`.
-
-.. _fls_pqunxp6io1n9:
 
 immutable borrow expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_dojod5pg4r7l`
 An :dt:`immutable borrow expression` is a :t:`borrow expression` that lacks
 :t:`keyword` ``mut``.
-
-.. _fls_TXQzFM77s4uj:
 
 immutable place expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_MXBEZjzBxw5Z`
 An :dt:`immutable place expression` is a :t:`place expression` whose memory
 location cannot be modified.
 
 
-.. _fls_O0924m8mSfIa:
-
 immutable place expression context
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_UvrQ49dSoQGc`
 An :dt:`immutable place expression context` is a :t:`place expression context`
 whose memory location cannot be modified.
-
-.. _fls_RghQKP3lsXEb:
 
 immutable raw pointer type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2GzYItDXvMhB`
 An :dt:`immutable raw pointer type` is a :t:`raw pointer type` subject to
 :t:`keyword` ``const``.
-
-.. _fls_bhx0l676dmgc:
 
 immutable reference
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_u9kne5zfmhoe`
 An :dt:`immutable reference` is a :t:`value` of a :t:`shared reference type`,
 and prevents the mutation of its :t:`referent`.
-
-.. _fls_my7jjwi0ncen:
 
 immutable static
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_eonlhz79ur3d`
 An :dt:`immutable static` is a :t:`static` whose :t:`value` cannot be modified.
-
-.. _fls_8xrhfwgep3nk:
 
 immutable variable
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_sdg35i92taip`
 An :dt:`immutable variable` is a :t:`variable` whose :t:`value` cannot be
 modified.
-
-.. _fls_L9XTxPSujx4v:
 
 impl header lifetime elision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_PvYGu85UAyFb`
 :dt:`Impl header lifetime elision` is a form of :t:`lifetime elision` that
 applies to the :t:`implementing type` and :t:`implemented trait` (if any) of an
 :t:`implementation`.
 
-.. _fls_l20o3hutbfpf:
-
 impl trait type
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_rdctgmnfncnd`
 An :dt:`impl trait type` is a :t:`type` that implements a :t:`trait`, where the
 :t:`type` is known at compile time.
 
-:dp:`fls_704soar15v8v`
 See :s:`ImplTraitTypeSpecification`, :s:`ImplTraitTypeSpecificationOneBound`.
-
-.. _fls_bj1u4k3akecp:
 
 implementation
 ^^^^^^^^^^^^^^
 
-:dp:`fls_pjulppit1r6`
 An :dt:`implementation` is an :t:`item` that supplements an
 :t:`implementing type` by extending its functionality.
 
-:dp:`fls_z4ij5skptoay`
 See :s:`Implementation`.
-
-.. _fls_vofxuHcXpt6X:
 
 implementation body
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_1iS30Nv9myEd`
 An :dt:`implementation body` is a :t:`construct` that encapsulates the
 :t:`[associated item]s`, :t:`[inner attribute]s`, and
 :t:`[inner doc comment]s` of an :t:`implementation`.
 
-:dp:`fls_u75iHi53PnNP`
 See :s:`ImplementationBody`.
-
-.. _fls_41GLrzVxcOV6:
 
 implementation coherence
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hAmKcuYT9hHi`
 A :t:`trait implementation` exhibits :dt:`implementation coherence` when it is
 valid and does not overlap with another :t:`trait implementation`.
-
-.. _fls_SBkTVa8bzGDx:
 
 implementation conformance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Gpq4EP1SsYJR`
 :dt:`Implementation conformance` measures the compatibility between a
 :t:`trait implementation` and the :t:`implemented trait`.
-
-.. _fls_c0xxvivt8t1u:
 
 implemented trait
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7twlizi3v8cb`
 An :dt:`implemented trait` is a :t:`trait` whose functionality has been
 implemented by an :t:`implementing type`.
 
-:dp:`fls_2brvfx5wmvkf`
 See :s:`ImplementedTrait`.
-
-.. _fls_ow4b5iqas115:
 
 implementing type
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_vs5ia3uupdcc`
 An :dt:`implementing type` is the :t:`type` that the :t:`[associated item]s` of
 an :t:`implementation` are associated with.
 
-:dp:`fls_9ixcwh6to74g`
 See :s:`ImplementingType`.
-
-.. _fls_wa7t6cqgjksd:
 
 implicit borrow
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_q2v9ejpcvtwg`
 An :dt:`implicit borrow` is a :t:`borrow` that is not present syntactically in
 program text.
-
-.. _fls_i3iB9xP8h8Ci:
 
 implicitly declared entity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_VQs1jd4Nx3qR`
 An :dt:`implicitly declared entity` is an :t:`entity` that lacks an explicit
 :t:`declaration`.
-
-.. _fls_43CCrG952l5i:
 
 implied bound
 ^^^^^^^^^^^^^
 
-:dp:`fls_t77d8xwG1l9Q`
 An :dt:`implied bound` is a :t:`bound` that is not expressed in syntax, but is the byproduct of relations between :t:`[lifetime parameter]s` and :t:`[function parameter]s`, between :t:`[lifetime parameter]s` and a :t:`return type`, and between :t:`[lifetime parameter]s` and :t:`[field]s`.
-
-.. _fls_3lo8ygoyxxyf:
 
 in scope
 ^^^^^^^^
 
-:dp:`fls_sy380geqvf2l`
 A :t:`name` is :dt:`in scope` when it can be referred to.
-
-.. _fls_nscfxu6huw6q:
 
 inclusive range pattern
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_olfeuvwkosse`
 An :dt:`inclusive range pattern` is a :t:`range pattern` with both a
 :t:`range pattern low bound` and a :t:`range pattern high bound`.
 
-:dp:`fls_9bdxsn6nasjr`
 See :s:`InclusiveRangePattern`.
-
-.. _fls_j44ow2k5va3s:
 
 incomplete associated constant
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_bq48gl84bul0`
 An :dt:`incomplete associated constant` is an :t:`associated constant` without
 a :t:`constant initializer`.
-
-.. _fls_ga2n4nbm1pkk:
 
 incomplete associated function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_iboondra204w`
 An :dt:`incomplete associated function` is an :t:`associated function` without
 a :t:`function body`.
-
-.. _fls_n99acc2tr9qm:
 
 incomplete associated type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tka0gth8rc9x`
 An :dt:`incomplete associated type` is an :t:`associated type` without an
 :t:`initialization type`.
-
-.. _fls_6tysvlg2ifr3:
 
 index expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_1f7e9q8n431n`
 An :dt:`index expression` is an :t:`expression` that indexes into a :t:`value`
 of a :t:`type`.
 
-:dp:`fls_xm2er7vuo07g`
 See :s:`IndexExpression`.
-
-.. _fls_S0pnJKPJPU0i:
 
 indexable type
 ^^^^^^^^^^^^^^
 
-:dp:`fls_AdVGyKZFvvUS`
 A :dt:`indexable type` is a :t:`type` that implements the
 :std:`core::ops::Index` :t:`trait`.
-
-.. _fls_qs654p61ivpx:
 
 indexed deconstructor
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_q7eta38vw0ig`
 An :dt:`indexed deconstructor` is a :t:`construct` that matches the position of
 a :t:`tuple field`.
 
-:dp:`fls_gryv4audvann`
 See :s:`IndexedDeconstructor`.
-
-.. _fls_bu46dg60o8us:
 
 indexed field selector
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_u6mh5yediub`
 An :dt:`indexed field selector` is a :t:`field selector` where the selected
 :t:`field` is indicated by an index.
 
-:dp:`fls_wbbyf2szc8a7`
 See :s:`IndexedFieldSelector`.
-
-.. _fls_rua2ni3p9qz2:
 
 indexed initializer
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_oonqolgqyrq1`
 An :dt:`indexed initializer` is a :t:`construct` that specifies the index and
 initial :t:`value` of a :t:`field` in a :t:`struct expression`.
 
-:dp:`fls_werlw98l3ra0`
 See :s:`IndexedInitializer`.
-
-.. _fls_irp9ive4e66r:
 
 indexed operand
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_dvmm47wnl33e`
 An :dt:`indexed operand` is an :t:`operand` which indicates the :t:`value` of a
 :t:`type` implementing :std:`core::ops::Index` being indexed into by an
 :t:`index expression`.
 
-:dp:`fls_je8eh3a02riq`
 See :s:`IndexedOperand`.
-
-.. _fls_a350zwl1or4g:
 
 indexing operand
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_ipw4tfrserbu`
 An :dt:`indexing operand` is an :t:`operand` which specifies the index for the
 :t:`indexed operand` being indexed into by an :t:`index expression`.
 
-:dp:`fls_t2j8vzlrlvb0`
 See :s:`IndexingOperand`.
-
-.. _fls_k9kuxgte6vxn:
 
 indirection type
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_8so1phpdjyk8`
 An :dt:`indirection type` is a :t:`type` whose :t:`[value]s` refer to memory
 locations.
-
-.. _fls_gccnknktzp7g:
 
 inert attribute
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_o4e3tyjz7l1h`
 An :dt:`inert attribute` is an :t:`attribute` that remains with the :t:`item`
 it decorates.
-
-.. _fls_z5593p7wfab:
 
 inferred type
 ^^^^^^^^^^^^^
 
-:dp:`fls_9xgfexeqr4ed`
 An :dt:`inferred type` is a placeholder for a :t:`type` deduced by
 :t:`type inference`.
 
-:dp:`fls_z2p8378sd93z`
 See :s:`InferredType`.
-
-.. _fls_kg9aeyrw822m:
 
 infinite loop
 ^^^^^^^^^^^^^
 
-:dp:`fls_xpm53i3rkuu0`
 For :dt:`infinite loop`, see :t:`infinite loop expression`.
-
-.. _fls_o2eei5aqgds6:
 
 infinite loop expression
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mvplpa4t1f2p`
 An :dt:`infinite loop expression` is a :t:`loop expression` that continues to
 evaluate its :t:`loop body` indefinitely.
 
-:dp:`fls_2gipk6b62hme`
 See :s:`InfiniteLoopExpression`.
-
-.. _fls_o57p4yhjci61:
 
 inherent implementation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6fpicw8ss4h3`
 An :dt:`inherent implementation` is an :t:`implementation` that adds direct
 functionality.
 
-:dp:`fls_s8zjk7hms1o0`
 See :s:`InherentImplementation`.
-
-.. _fls_c1wbumq0bumj:
 
 initialization
 ^^^^^^^^^^^^^^
 
-:dp:`fls_xi07ycze6mo0`
 :dt:`Initialization` is the act of supplying an initial :t:`value` to a
 :t:`constant`, a :t:`static`, or a :t:`variable`.
-
-.. _fls_ctusGvpQvJue:
 
 initialization expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_KUeiSByPUc4w`
 An :dt:`initialization expression` is either a :t:`constant initializer` or a
 :t:`static initializer`.
-
-.. _fls_pd30dl2envjn:
 
 initialization type
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_crn87nne7k38`
 An :dt:`initialization type` is the :t:`type` a :t:`type alias` defines a
 :t:`name` for.
 
-:dp:`fls_3r85y1lh1oxo`
 See :s:`InitializationType`.
-
-.. _fls_lbL2b9wyg6es:
 
 inline assembly
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_1MtaLEA7YfSv`
 :dt:`Inline assembly` is hand-written assembly code that is integrated into a
 Rust program.
-
-.. _fls_K1MwUj4jqd0F:
 
 inline assembly argument
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Q7qnUo0GskSV`
 An :dt:`inline assembly argument` is either an :t:`assembly instruction`, a :t:`register argument`, an :t:`ABI clobber`, or an :t:`assembly option`.
-
-.. _fls_c54lmkluwbwr:
 
 inline module
 ^^^^^^^^^^^^^
 
-:dp:`fls_tbldwtisl9vc`
 An :dt:`inline module` is a :t:`module` with an :s:`InlineModuleSpecification`.
 
-:dp:`fls_8bmjz8o3xu60`
 See :s:`InlineModuleSpecification`.
-
-.. _fls_joxepyv84ajz:
 
 inner attribute
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_l7kxkav42l5d`
 An :dt:`inner attribute` is an :t:`attribute` that applies to an enclosing
 :t:`item`.
 
-:dp:`fls_umkk8xwktat1`
 See :s:`InnerAttribute`.
-
-.. _fls_chbp2je32okc:
 
 inner block doc
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_f4nqkybpwj1a`
 An :dt:`inner block doc` is a :t:`block comment` that applies to an enclosing
 :t:`non-[comment]` :t:`construct`.
 
-:dp:`fls_lmpaznk198ga`
 See :s:`InnerBlockDoc`.
-
-.. _fls_vR1ucGTBKjlH:
 
 inner doc comment
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6KunKwZf9QaF`
 An :dt:`inner doc comment` is either an :t:`inner block doc` or an
 :t:`inner line doc`.
-
-.. _fls_xgm53126q9c4:
 
 inner line doc
 ^^^^^^^^^^^^^^
 
-:dp:`fls_vtwavwjhgvlz`
 An :dt:`inner line doc` is a :t:`line comment` that applies to an enclosing
 :t:`non-[comment]` :t:`construct`.
 
-:dp:`fls_8cnikewkqs7`
 See :s:`InnerLineDoc`.
-
-.. _fls_DTb5xegDqm9S:
 
 input register
 ^^^^^^^^^^^^^^
 
-:dp:`fls_dTvdQaFpncCj`
 An :dt:`input register` is a :t:`register` whose :t:`register name` is used in
 a :t:`register argument` subject to :t:`direction modifier` ``in``, ``inout``,
 or ``inlateout``.
 
-.. _fls_Tmju2kXErYhJ:
-
 input register expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rvbuHSgg2RHt`
 An :dt:`input register expression` is an :t:`expression` that provides the
 initial :t:`value` of a :t:`register`.
 
-:dp:`fls_NqjRr9khzpl2`
 See :s:`InputRegisterExpression`.
-
-.. _fls_y9EOkstHPckB:
 
 input-output register expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lLQw3EFl7x5z`
 An :dt:`input-output register expression` is a :t:`construct` that specifies
 both an :t:`input register expression` and an :t:`output register expression`.
 
-:dp:`fls_FnMGXi2nPgUH`
 See :s:`InputOutputRegisterExpression`.
-
-.. _fls_e2kizieowvuh:
 
 integer literal
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_23a1fjpf15qv`
 An :dt:`integer literal` is a :t:`numeric literal` that denotes a whole number.
 
-:dp:`fls_6qpj0nr0jpjr`
 See :s:`IntegerLiteral`.
-
-.. _fls_bhvh8qwqy8ve:
 
 integer suffix
 ^^^^^^^^^^^^^^
 
-:dp:`fls_qazh8f8rs528`
 An :dt:`integer suffix` is a component of an :t:`integer literal` that
 specifies an explicit :t:`integer type`.
 
-:dp:`fls_jqagv350kw2m`
 See ``IntegerSuffix.``
-
-.. _fls_nu1cnk2b9qx5:
 
 integer type
 ^^^^^^^^^^^^
 
-:dp:`fls_nhfqdhf26ym3`
 An :dt:`integer type` is a :t:`numeric type` whose :t:`[value]s` denote whole
 numbers.
-
-.. _fls_ctuvilpb30gq:
 
 integer type variable
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_e3ed1tyrjsy4`
 An :dt:`integer type variable` is a :t:`type variable` that can refer only to
 :t:`[integer type]s`.
-
-.. _fls_mb3xnplwdw9l:
 
 interior mutability
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_e0173dd09znl`
 :dt:`Interior mutability` is a property of :t:`[type]s` whose :t:`[value]s` can
 be modified through :t:`[immutable reference]s`.
-
-.. _fls_7rj914fhginh:
 
 intermediate match arm
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_l6pemxmdllvl`
 An :dt:`intermediate match arm` is any :t:`non-[final match arm]` of a
 :t:`match expression`.
 
-:dp:`fls_8713j5lrwqvs`
 See :s:`IntermediateMatchArm`.
-
-.. _fls_fgmvmcw2kw5i:
 
 irrefutable constant
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hd02jah50qzl`
 An :dt:`irrefutable constant` is a :t:`constant` of a :t:`type` that has at most
 one :t:`value`.
 
 
-.. _fls_ckz7pujdnuo5:
-
 irrefutable pattern
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_y421hdrbs6ak`
 An :dt:`irrefutable pattern` is a :t:`pattern` that always matches the
 :t:`value` it is being matched against.
-
-.. _fls_vt44bvhm4duk:
 
 isize
 ^^^^^
 
-:dp:`fls_6x617i9zcj7o`
 :dc:`isize` is a :t:`signed integer type` with the same number of bits as the
 platform's :t:`pointer type`, and is at least 16-bits wide.
-
-.. _fls_yh2a7e3d3894:
 
 item
 ^^^^
 
-:dp:`fls_2ghaujiqkhyy`
 An :dt:`item` is the most basic semantic element in program text. An item
 defines the compile- and run-time semantics of a program.
 
-:dp:`fls_xd997kd2i73a`
 See :s:`Item`.
-
-.. _fls_wojJZZ4gYGfl:
 
 item scope
 ^^^^^^^^^^
 
-:dp:`fls_mW7IwWGSjrl2`
 An :dt:`item scope` is a :t:`scope` for :t:`[item]s`.
-
-.. _fls_yaurxo4ogfsh:
 
 item statement
 ^^^^^^^^^^^^^^
 
-:dp:`fls_r0crucpuhtj`
 An :dt:`item statement` is a :t:`statement` that is expressed as an :t:`item`.
-
-.. _fls_orde7iunolyx:
 
 iteration expression
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_suz163n1x1xm`
 An :dt:`iteration expression` is an :t:`expression` that provides the criterion
 of a :t:`while loop expression`.
 
-:dp:`fls_jw5lj2hgjl8v`
 See :s:`IterationExpression`.
-
-.. _fls_yjs58mp5fkxz:
 
 keyword
 ^^^^^^^
 
-:dp:`fls_z3825koc9c1w`
 A :dt:`keyword` is a word in program text that has special meaning.
 
-:dp:`fls_yvnf2mu4pr75`
 See :s:`Keyword`.
-
-.. _fls_uVUoHmNtPRtS:
 
 label
 ^^^^^
 
-:dp:`fls_iAAf2rLmgmGQ`
 A :dt:`label` is the :t:`name` of a :t:`loop expression`.
 
-:dp:`fls_HicurdHIiLX2`
 See :s:`Label`.
-
-.. _fls_dw5s7jhk4v8s:
 
 label indication
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_sso322p7adt0`
 A :dt:`label indication` is a :t:`construct` that indicates a :t:`label`.
 
-:dp:`fls_g6iqfqooz8th`
 See :s:`LabelIndication`.
-
-.. _fls_P0on44EAB3cn:
 
 label scope
 ^^^^^^^^^^^
 
-:dp:`fls_2H6HkQ102hVS`
 A :dt:`label scope` is a :t:`scope` for :t:`[label]s`.
-
-.. _fls_w5gslebevlya:
 
 layout
 ^^^^^^
 
-:dp:`fls_qk602dmhc0d6`
 :dt:`Layout` specifies the :t:`alignment`, :t:`size`, and the relative offset
 of :t:`[field]s` in a :t:`type`.
-
-.. _fls_bputdgkeezfs:
 
 lazy and expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_v2e6t73uk6nt`
 A :dt:`lazy and expression` is a :t:`lazy boolean expression` that uses short
 circuit and arithmetic.
 
-:dp:`fls_rkthjuvems6v`
 See :s:`LazyAndExpression`.
-
-.. _fls_4a6yhxj783a1:
 
 lazy boolean expression
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_jpv7l86sdh6i`
 A :dt:`lazy boolean expression` is an :t:`expression` that performs short
 circuit Boolean arithmetic.
 
-:dp:`fls_9tu5x810ztbg`
 See :s:`LazyBooleanExpression`.
-
-.. _fls_9mvrfhsegwp0:
 
 lazy or expression
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_aln8bbvx9kzm`
 A :dt:`lazy or expression` is a :t:`lazy boolean expression` that uses short
 circuit or arithmetic.
 
-:dp:`fls_jiv7e3mr86kf`
 See :s:`LazyOrExpression`.
-
-.. _fls_x6vo9pysmex2:
 
 left operand
 ^^^^^^^^^^^^
 
-:dp:`fls_m821x5195ac9`
 A :dt:`left operand` is an :t:`operand` that appears on the left-hand side of a
 :t:`binary operator`.
 
-:dp:`fls_ghlbsklg7wdb`
 See :s:`LeftOperand`.
-
-.. _fls_ulmspewtlo57:
 
 less-than expression
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_9ttxqxt9ui4t`
 A :dt:`less-than expression` is a :t:`comparison expression` that tests for a
 less-than relationship.
 
-:dp:`fls_rhnbdyo2l4kp`
 See :s:`LessThanExpression`.
-
-.. _fls_es169x7ars9a:
 
 less-than-or-equals expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8pya58ug180j`
 A :dt:`less-than-or-equals expression` is a :t:`comparison expression` that
 tests for a less-than-or-equals relationship.
 
-:dp:`fls_ft5aeo4ilgwc`
 See :s:`LessThanOrEqualsExpression`.
 
-
-.. _fls_DdZ1ZwjLZTeG:
 
 let binding
 ^^^^^^^^^^^
 
-:dp:`fls_sw6HrsxsnG2y`
 A :dt:`let binding` is the :t:`binding` introduced by a :t:`let statement`, an :t:`if let expression`, or a :t:`while let loop expression`.
-
-.. _fls_hqj80jHcxEBB:
 
 let initializer
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_jtTpBZ4ujZRc`
 A :dt:`let initializer` is a :t:`construct` that provides the :t:`value` of
 the :t:`[binding]s` of the :t:`let statement` using an :t:`expression`, or
 alternatively executes a :t:`block expression`.
 
-:dp:`fls_GmHsJb6FICfA`
 See :s:`LetInitializer`.
-
-.. _fls_39k0ebr7snb0:
 
 let statement
 ^^^^^^^^^^^^^
 
-:dp:`fls_yh7hn6jjv3ur`
 A :dt:`let statement` is a :t:`statement` that introduces new :t:`[variable]s`
 given by the :t:`[binding]s` produced by its :t:`pattern-without-alternation`
 that are optionally initialized to a :t:`value`.
 
-:dp:`fls_tsem3c6zqmh4`
 See :s:`LetStatement`.
-
-.. _fls_h2tqtmm5686y:
 
 lexical element
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_nrxnbkatn63n`
 A :dt:`lexical element` is the most basic syntactic element in program
 text.
-
-.. _fls_r1sk7vdgckym:
 
 library crate
 ^^^^^^^^^^^^^
 
-:dp:`fls_3m8lg4mdc2x0`
 A :dt:`library crate` is a :t:`crate` whose :t:`crate type` is ``lib``, ``rlib``,
 ``staticlib``, ``dylib``, or ``cdylib``.
-
-.. _fls_vdhaa61g6kah:
 
 lifetime
 ^^^^^^^^
 
-:dp:`fls_il3n0w4m084b`
 A :dt:`lifetime` specifies the expected longevity of a :t:`reference`.
 
-:dp:`fls_2nywjifee7q`
 See :s:`Lifetime`.
-
-.. _fls_d0s6bk7ljqrb:
 
 lifetime argument
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_oaf87yjb3xjs`
 A :dt:`lifetime argument` is a :t:`generic argument` that supplies the
 :t:`value` of a :t:`lifetime parameter`.
 
-:dp:`fls_la8lbv14zj28`
 See :s:`LifetimeArgument`.
-
-.. _fls_ca9pu348r9jm:
 
 lifetime bound
 ^^^^^^^^^^^^^^
 
-:dp:`fls_u6xfs8fg558`
 A :dt:`lifetime bound` is a :t:`bound` that imposes a constraint on the
 :t:`[lifetime]s` of :t:`[generic parameter]s`.
 
-:dp:`fls_ivcjmp54hdej`
 See :s:`LifetimeIndication`.
-
-.. _fls_fV8sP0roRyBN:
 
 lifetime bound predicate
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_AHftLKgSP9Xk`
 A :dt:`lifetime bound predicate` is a :t:`construct` that specifies
 :t:`[lifetime bound]s` on a :t:`lifetime parameter`.
 
-:dp:`fls_8WIod9Rm5IXa`
 See :s:`LifetimeBoundPredicate`.
-
-.. _fls_al39r9uz2zmy:
 
 lifetime elision
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_dq5wkd61ry3l`
 :dt:`Lifetime elision` is a set of rules that automatically insert
 :t:`[lifetime parameter]s` and/or :t:`[lifetime argument]s` when they are
 elided in the source code.
 
-.. _fls_md7ii59zobrc:
-
 lifetime parameter
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7g0iu68nrsd4`
 A :dt:`lifetime parameter` is a :t:`generic parameter` for a :t:`lifetime`.
 
-:dp:`fls_z1wl2uiwip98`
 See :s:`LifetimeParameter`.
-
-.. _fls_joDjnHu1L9Lp:
 
 lifetime variable
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ucZnCBWxXl6n`
 A :dt:`lifetime variable` is a placeholder used during :t:`type inference` to
 stand in for an undetermined :t:`lifetime` of a :t:`type`.
 
 
-.. _fls_8qputmx0i7ku:
-
 line
 ^^^^
 
-:dp:`fls_oqf2439j3y7b`
 A :dt:`line` is a sequence of zero or more characters followed by an end of
 line.
-
-.. _fls_k5ycqijslkxh:
 
 line comment
 ^^^^^^^^^^^^
 
-:dp:`fls_3e7asah7lkqj`
 A :dt:`line comment` is a :t:`comment` that spans exactly one :t:`line`.
 
-:dp:`fls_8j5j777dv2jm`
 See :s:`LineComment`.
-
-.. _fls_z850pyf9r1f4:
 
 literal
 ^^^^^^^
 
-:dp:`fls_ckbyt11pku9j`
 A :dt:`literal` is a fixed :t:`value` in program text.
 
-:dp:`fls_h1g46cevrqjv`
 See :s:`Literal`.
-
-.. _fls_b57clq8jhw5w:
 
 literal expression
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_otaauusc24v5`
 A :dt:`literal expression` is an :t:`expression` that denotes a :t:`literal`.
 
-:dp:`fls_7po7zobtlhzn`
 See :s:`LiteralExpression`.
-
-.. _fls_bo2tv8ky1jc:
 
 literal pattern
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_5s9b4bza13xf`
 A :dt:`literal pattern` is a :t:`pattern` that matches a :t:`literal`.
 
-:dp:`fls_o7q7wfjulc24`
 See :s:`LiteralPattern`.
-
-.. _fls_bYpBl5zfTibF:
 
 local trait
 ^^^^^^^^^^^
 
-:dp:`fls_H5vkbMFvzrFs`
 A :dt:`local trait` is a :t:`trait` that is defined in the current :t:`crate`.
-
-.. _fls_cexgUIGUUKS4:
 
 local type
 ^^^^^^^^^^
 
-:dp:`fls_HvGPB3CsN4Ah`
 A :dt:`local type` is a :t:`type` that is defined in the current :t:`crate`.
-
-.. _fls_lkxiws55xhpq:
 
 local variable
 ^^^^^^^^^^^^^^
 
-:dp:`fls_3inlcyi6444u`
 For :dt:`local variable`, see :t:`variable`.
-
-.. _fls_kdqa8zs8tk6g:
 
 loop
 ^^^^
 
-:dp:`fls_omjnvxva07z2`
 For :dt:`loop`, see :t:`loop expression`.
-
-.. _fls_5vt0Ph5BfDnU:
 
 loop body
 ^^^^^^^^^
 
-:dp:`fls_fRWcWPeKgx9g`
 A :dt:`loop body` is the :t:`block expression` of a :t:`loop expression`.
 
-:dp:`fls_vWuR2TET712r`
 See :s:`LoopBody`.
-
-.. _fls_an1s2hnapd59:
 
 loop expression
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_2yypq3m1kquj`
 A :dt:`loop expression` is an :t:`expression` that evaluates a
 :t:`block expression` continuously as long as some criterion holds true.
 
-:dp:`fls_o2dyznhq7rez`
 See :s:`LoopExpression`.
-
-.. _fls_sdkcn1exc9da:
 
 macro
 ^^^^^
 
-:dp:`fls_bt16qi8g2js5`
 A :dt:`macro` is a custom definition that extends Rust by defining callable
 syntactic transformations.
-
-.. _fls_td4jm76u9m03:
 
 macro expansion
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_t383uo1l4h8x`
 :dt:`Macro expansion` is the process of statically executing a
 :t:`macro invocation` and replacing it with the produced output of the
 :t:`macro invocation`.
 
-.. _fls_o5jy1u64nyiy:
-
 macro implementation function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xy4t1suhrn46`
 A :dt:`macro implementation function` is the :t:`function` that encapsulates
 the syntactic transformations of a :t:`procedural macro`.
-
-.. _fls_20x9eqa7xeui:
 
 macro invocation
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_5qtwcp5ns5vz`
 A :dt:`macro invocation` is a call of a :t:`declarative macro` or
 :t:`function-like macro` that is expanded statically and replaced with the
 result of the :t:`macro`.
 
-:dp:`fls_IgzL0OJ9Ja7y`
 See :s:`MacroInvocation`.
-
-.. _fls_boanb1ipzc9:
 
 macro match
 ^^^^^^^^^^^
 
-:dp:`fls_q0ve6nd287ta`
 A :dt:`macro match` is the most basic form of a satisfied :t:`macro matcher`.
 
-:dp:`fls_dww6sqbj2vin`
 See :s:`MacroMatch`.
-
-.. _fls_4h4snjd4thsv:
 
 macro matcher
 ^^^^^^^^^^^^^
 
-:dp:`fls_sqncf88chnsy`
 A :dt:`macro matcher` is a :t:`construct` that describes a syntactic pattern
 that a :t:`macro` must match.
 
-:dp:`fls_ioyegc6ggd7o`
 See :s:`MacroMatcher`.
-
-.. _fls_ao7GhE0C8MQO:
 
 macro matching
 ^^^^^^^^^^^^^^
 
-:dp:`fls_RrDmFXuZrhFT`
 :dt:`Macro matching` is the process of performing :t:`rule matching` and
 :t:`token matching`.
-
-.. _fls_kddW7EirSn0g:
 
 macro repetition
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_sDomcFWIeUAT`
 A :dt:`macro repetition` is either a :t:`macro repetition in matching` or a
 :t:`macro repetition in transcription`.
-
-.. _fls_a5j2hztrjfv5:
 
 macro repetition in matching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wio0e9qzstjh`
 A :dt:`macro repetition in matching` allows for a syntactic pattern to be
 matched zero or multiple times during :t:`macro matching`.
 
-:dp:`fls_potk1y850zer`
 See :s:`MacroRepetitionMatch`.
-
-.. _fls_sqv126lwdz23:
 
 macro repetition in transcription
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ex9vd3w0t4wo`
 A :dt:`macro repetition in transcription` allows for a syntactic pattern to be
 transcribed zero or multiple times during :t:`macro transcription`.
 
-:dp:`fls_5wdiqbwgr9nt`
 See :s:`MacroRepetitionTranscriber`.
-
-.. _fls_gw31cagmzx26:
 
 macro rule
 ^^^^^^^^^^
 
-:dp:`fls_7gfdqggs33id`
 A :dt:`macro rule` is a :t:`construct` that consists of a :t:`macro matcher`
 and a :t:`macro transcriber`.
 
-:dp:`fls_qv68aj43mz5m`
 See :s:`MacroRule`.
-
-.. _fls_i4yf4lt8qvkt:
 
 macro statement
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_yhh9k9epv3g6`
 A :dt:`macro statement` is a :t:`statement` expressed as a
 :t:`terminated macro invocation`.
-
-.. _fls_76o6rjh6lrqd:
 
 macro transcriber
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ug79qf3p693h`
 A :dt:`macro transcriber` is a :t:`construct` that describes the replacement
 syntax of a :t:`macro`.
 
-:dp:`fls_myubuihvjl4s`
 See :s:`MacroTranscriber`.
-
-.. _fls_vdq3cphhpxmg:
 
 macro transcription
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_nouiggbpipg`
 :dt:`Macro transcription` is the process of producing the expansion of a
 :t:`declarative macro`.
-
-.. _fls_MJ1YWiOpxAa8:
 
 main function signature
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_QijObGZEIykU`
 A :dt:`main function signature` is a :t:`function signature` subject to specific
 restrictions.
-
-.. _fls_fizf1byuspv2:
 
 match arm
 ^^^^^^^^^
 
-:dp:`fls_z5qsy5z2zak3`
 A :dt:`match arm` is a :t:`construct` that consists of a :t:`match arm matcher`
 and a :t:`match arm body`.
-
-.. _fls_q7lcdtxuy1ac:
 
 match arm body
 ^^^^^^^^^^^^^^
 
-:dp:`fls_33e7oefx0xqm`
 A :dt:`match arm body` is the :t:`operand` of a :t:`match arm`.
-
-.. _fls_aa1x6ajl4zid:
 
 match arm guard
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_uhn07jmvv9ea`
 A :dt:`match arm guard` is a :t:`construct` that provides additional filtering
 to a :t:`match arm matcher`.
 
-:dp:`fls_ykf70vbng54n`
 See :s:`MatchArmGuard`.
-
-.. _fls_i3omadaygum2:
 
 match arm matcher
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_paz9358w4cpu`
 A :dt:`match arm matcher` is a :t:`construct` that consists of a :t:`pattern`
 and a :t:`match arm guard`.
 
-:dp:`fls_j7i2bjvzz1tx`
 See :s:`MatchArmMatcher`.
-
-.. _fls_w15uouo0sjao:
 
 match expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_2ohrphptjny6`
 A :dt:`match expression` is an :t:`expression` that tries to match one of
 its multiple :t:`[pattern]s` against its :t:`subject expression` and if it
 succeeds, evaluates an :t:`operand`.
 
-:dp:`fls_wkalvzkmp95y`
 See :s:`MatchExpression`.
-
-.. _fls_xo9uyazcfuq3:
 
 metavariable
 ^^^^^^^^^^^^
 
-:dp:`fls_fu1esz5i9mt`
 A :dt:`metavariable` is a :t:`macro match` that describes a :t:`variable`.
 
-:dp:`fls_k4xaw93z8x33`
 See :s:`MacroMetavariable`.
-
-.. _fls_5P2594jy7uDE:
 
 metavariable indication
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_r1FxbWffC9Wt`
 A :dt:`metavariable indication` is a :t:`construct` that indicates a
 :t:`metavariable`.
 
-:dp:`fls_bcMO2a0e0gXJ`
 See :s:`MacroMetavariableIndication`.
-
-.. _fls_bi3g8xkk9ekf:
 
 method
 ^^^^^^
 
-:dp:`fls_n4opbiofu9q6`
 A :dt:`method` is an :t:`associated function` with a :t:`self parameter`.
-
-.. _fls_l4wel2551cw9:
 
 method call expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_367sod24edts`
 A :dt:`method call expression` is an :t:`expression` that invokes a :t:`method`
 of a :t:`variable`.
 
-:dp:`fls_ohhcvxcaqv11`
 See :s:`MethodCallExpression`.
-
-.. _fls_l6eJxvmplLqQ:
 
 method operand
 ^^^^^^^^^^^^^^
 
-:dp:`fls_VLLAFjAxCfkE`
 A :dt:`method operand` is an :t:`operand` that denotes the :t:`method` being
 invoked by a :t:`method call expression`.
 
-:dp:`fls_Pkgr4fJQZpJ6`
 See :s:`MethodOperand`.
-
-.. _fls_05yFh5Ud0YkW:
 
 method resolution
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_LbW4z6OTuD1l`
 :dt:`Method resolution` is a kind of :t:`resolution` that applies to a
 :t:`method call expression`.
-
-.. _fls_2FFRdj5cO0ks:
 
 mixed site hygiene
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hjJpNmKiZxlT`
 :dt:`Mixed site hygiene` is a type of :t:`hygiene` which resolves to the
 :s:`MacroRulesDeclaration` site for :t:`[variable]s`, :t:`[label]s`, and the
 ``$crate`` :t:`metavariable`, and to the :s:`MacroInvocation` site otherwise,
 and is considered :t:`partially hygienic`.
 
-.. _fls_5hoe1v960xfi:
-
 modifying operand
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_9wt2l5gg06pb`
 A :dt:`modifying operand` is an :t:`operand` that supplies the :t:`value` that
 is used in the calculation of a :t:`compound assignment expression`.
 
-:dp:`fls_qnwbrwdnv7n0`
 See :s:`ModifyingOperand`.
-
-.. _fls_kbxk78vm564e:
 
 module
 ^^^^^^
 
-:dp:`fls_ujlsg58bskl5`
 A :dt:`module` is a container for zero or more :t:`[item]s`.
 
-:dp:`fls_os60q6vvm71c`
 See :s:`ModuleDeclaration`.
-
-.. _fls_gnucgrytswa4:
 
 move type
 ^^^^^^^^^
 
-:dp:`fls_ri37ez31gai8`
 A :dt:`move type` is a :t:`type` that implements the :std:`core::marker::Sized`
 :t:`trait` and that is not a :t:`copy type`.
-
-.. _fls_iw2vYgmLhlsg:
 
 multi segment path
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_T4Xd6W6EqPSb`
 A :dt:`multi segment path` is a :t:`path` consisting of more than one
 :t:`path segment`.
-
-.. _fls_lpSCLhnaxeCg:
 
 multiplication assignment
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_llUb5VHKjwW4`
 For :dt:`multiplication assignment`, see
 :t:`multiplication assignment expression`.
-
-.. _fls_yo4k6lk0tizn:
 
 multiplication assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_eo9gx05n5ru3`
 A :dt:`multiplication assignment expression` is a
 :t:`compound assignment expression` that uses multiplication.
 
-:dp:`fls_b0dc5lec1mdc`
 See :s:`MultiplicationAssignmentExpression`.
-
-.. _fls_bgtznqqgtmd8:
 
 multiplication expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_324qh8wz474b`
 A :dt:`multiplication expression` is an :t:`arithmetic expression` that uses
 multiplication.
 
-:dp:`fls_34bkl5i75q5`
 See :s:`MultiplicationExpression`.
-
-.. _fls_yM11Bcxn4p7c:
 
 mutability
 ^^^^^^^^^^
 
-:dp:`fls_lBrXj9lo4s6o`
 :dt:`Mutability` determines whether a :t:`construct` can modify a :t:`value`.
-
-.. _fls_wvejcadmzt5p:
 
 mutable
 ^^^^^^^
 
-:dp:`fls_dqm58deu1orn`
 A :t:`value` is :dt:`mutable` when it can be modified.
-
-.. _fls_TEVPHHiCMByO:
 
 mutable assignee expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_0RSlFbwrB3gp`
 A :dt:`mutable assignee expression` is an :t:`assignee expression` whose
 :t:`value` can be modified.
-
-.. _fls_ntaA0NtJ9z5h:
 
 mutable binding
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_v2pGKVaQjtcl`
 A :dt:`mutable binding` is a :t:`binding` whose :t:`value` can be modified.
-
-.. _fls_iku91jwdtdr1:
 
 mutable borrow
 ^^^^^^^^^^^^^^
 
-:dp:`fls_5knwbyz4fd9z`
 A :dt:`mutable borrow` is a :t:`mutable reference` produced by :t:`borrowing`.
-
-.. _fls_kw3oiotr98tt:
 
 mutable borrow expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_80kcc4y21hu6`
 A :dt:`mutable borrow expression` is a :t:`borrow expression` that has
 :t:`keyword` ``mut``.
-
-.. _fls_7eyza445ew53:
 
 mutable place expression
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_kq877s3vij70`
 A :dt:`mutable place expression` is a :t:`place expression` whose memory
 location can be modified.
-
-.. _fls_x5BKVLc4KDlK:
 
 mutable place expression context
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2ixH8LWGHi3k`
 A :dt:`mutable place expression context` is a :t:`place expression context`
 that may evaluate its :t:`operand` as a mutable memory location.
-
-.. _fls_wOvlW47jKEWF:
 
 mutable raw pointer type
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_86SFxSDRcC06`
 A :dt:`mutable raw pointer type` is a :t:`raw pointer type` subject to
 :t:`keyword` ``mut``.
-
-.. _fls_jtzj092hyjkz:
 
 mutable reference
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wujjrhm1d338`
 A :dt:`mutable reference` is a :t:`value` of a :t:`mutable reference type`, and
 allows the mutation of its :t:`referent`.
-
-.. _fls_8iq0wcczl465:
 
 mutable reference type
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_q06p9tclwaaw`
 A :dt:`mutable reference type` is a :t:`reference type` subject to :t:`keyword`
 ``mut``.
-
-.. _fls_omgyj7yxwgua:
 
 mutable static
 ^^^^^^^^^^^^^^
 
-:dp:`fls_3ss4bokujaby`
 A :dt:`mutable static` is a :t:`static` whose :t:`value` can be modified.
-
-.. _fls_n7h4xr40xwgb:
 
 mutable variable
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_kjjv9jvdpf2o`
 A :dt:`mutable variable` is a :t:`variable` whose :t:`value` can be modified.
-
-.. _fls_kad7fzn94x4d:
 
 name
 ^^^^
 
-:dp:`fls_jjpzrs38vs3y`
 A :dt:`name` is an :t:`identifier` that refers to an :t:`entity`.
 
-:dp:`fls_yrzevg5kd4bi`
 See :s:`Name`.
-
-.. _fls_CxzbzLu4pWPY:
 
 named block expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ivFb8uAMVY3Q`
 A :dt:`named block expression` is a :t:`block expression` with a :t:`label`.
-
-.. _fls_dgs9y3nan69v:
 
 named deconstructor
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_g3k1hy3j4qn9`
 A :dt:`named deconstructor` is a :t:`construct` that matches the :t:`name` of
 a :t:`field`.
 
-:dp:`fls_ujreg07979g8`
 See :s:`NamedDeconstructor`.
-
-.. _fls_cvxdoycoytc5:
 
 named field selector
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_cczpgxqdyh1e`
 A :dt:`named field selector` is a :t:`field selector` where the selected
 :t:`field` is indicated by an :t:`identifier`.
 
-:dp:`fls_hpw0n89ez5nw`
 See :s:`NamedFieldSelector`.
-
-.. _fls_kp0mbopkbjer:
 
 named initializer
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xwvz8i4jim7a`
 A :dt:`named initializer` is a :t:`construct` that specifies the name and
 initial :t:`value` of a :t:`field` in a :t:`struct expression`.
 
-:dp:`fls_aueznbw3lohl`
 See :s:`NamedInitializer`.
-
-.. _fls_biwn3hxza37n:
 
 named loop expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_440dr5qix3ns`
 A :dt:`named loop expression` is a :t:`loop expression` with a :t:`label`.
-
-.. _fls_WT1ZdxTZwUUE:
 
 named register argument
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_QBWHppNO8FPk`
 A :dt:`named register argument` is a :t:`register argument` whose configuration
 is bound to an :t:`identifier`.
-
-.. _fls_GesmsWSVhv3f:
 
 namespace
 ^^^^^^^^^
 
-:dp:`fls_er8lcvnEqxa5`
 A :dt:`namespace` is a logical grouping of :t:`[name]s` such that the
 occurrence of a :t:`name` in one :t:`namespace` does not conflict with an
 occurrence of the same :t:`name` in another :t:`namespace`.
 
-.. _fls_z3lxbjF4gaqV:
-
 NaN-boxing
 ^^^^^^^^^^
 
-:dp:`fls_s956sJGwOa6z`
 :dt:`NaN-boxing` is a technique for encoding :t:`[value]s` using the low order
 bits of the mantissa of a 64-bit IEEE floating-point ``NaN``.
-
-.. _fls_3sp4twvfvb32:
 
 negation expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_pmn6cjamdt0a`
 A :dt:`negation expression` is an :t:`expression` that negates its :t:`operand`.
 
-:dp:`fls_o1f35ud4klvv`
 See :s:`NegationExpression`.
-
-.. _fls_6rlvd0u4w6h2:
 
 nesting import
 ^^^^^^^^^^^^^^
 
-:dp:`fls_nhkqkdqo32xs`
 A :dt:`nesting import` is a :t:`use import` that provides a common :t:`path`
 prefix for its nested :t:`[use import]s`.
 
-:dp:`fls_z4d611glen13`
 See :s:`NestingImport`.
-
-.. _fls_cwcbtnzbqmq2:
 
 never type
 ^^^^^^^^^^
 
-:dp:`fls_m9v5j6detob4`
 The :dt:`never type` is a :t:`type` that represents the result of a computation
 that never completes.
 
-:dp:`fls_k5z1vjxepnfj`
 See :s:`NeverType`.
-
-.. _fls_3vhflvajgqzd:
 
 non-reference pattern
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tejled5izyue`
 A :dt:`non-reference pattern` is any :t:`pattern` except
 :t:`non-[binding pattern]s`, :t:`[path pattern]s`, :t:`[reference pattern]s`,
 and :t:`[underscore pattern]s`.
 
-.. _fls_5u8ihVDp4mdb:
-
 not configuration predicate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_BVMlBterkFYq`
 A :dt:`not configuration predicate` is a :t:`configuration predicate` that
 negates the Boolean :t:`value` of its nested :t:`configuration predicate`.
 
-:dp:`fls_9j9AaNcv0VNA`
 See :s:`ConfigurationPredicateNot`.
-
-.. _fls_shgatqvpdqkg:
 
 not-equals expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2hmynl94uusk`
 A :dt:`not-equals expression` is a :t:`comparison expression` that tests for
 inequality.
 
-:dp:`fls_5d6vvr9m35n2`
 See :s:`NotEqualsExpression`.
-
-.. _fls_gqw1bzwexxt0:
 
 null
 ^^^^
 
-:dp:`fls_8sh17t37b2ml`
 A :dc:`null` :t:`value` denotes the address ``0``.
-
-.. _fls_a0qsojiymgjy:
 
 numeric literal
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_978ndaqdv4r`
 A :dt:`numeric literal` is a :t:`literal` that denotes a number.
 
-:dp:`fls_swue4tma9fmf`
 See :s:`NumericLiteral`.
-
-.. _fls_CmvuNXmowCz8:
 
 numeric literal pattern
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_azqQ3JxD5Lt7`
 A :dt:`numeric literal pattern` is a :t:`pattern` that matches a :t:`numeric
 literal`.
 
-:dp:`fls_QYDZm7pKy1nW`
 See :s:`LiteralPattern`.
-
-.. _fls_rayjriyofmpa:
 
 numeric type
 ^^^^^^^^^^^^
 
-:dp:`fls_cpdsj94l57af`
 A :dt:`numeric type` is a :t:`type` whose :t:`[value]s` denote numbers.
-
-.. _fls_a226qzrb4iq9:
 
 object safe
 ^^^^^^^^^^^
 
-:dp:`fls_oa2jiklr5nl2`
 A :t:`trait` is :dt:`object safe` when it can be used as a
 :t:`trait object type`.
-
-.. _fls_vomlqv7i1fc4:
 
 object safety
 ^^^^^^^^^^^^^
 
-:dp:`fls_vqmng1l9ab8a`
 :dt:`Object safety` is the process of determining whether a :t:`trait` can be
 used as a :t:`trait object type`.
-
-.. _fls_bo889w63y7oi:
 
 obsolete range pattern
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ave42vwb45zb`
 An :dt:`obsolete range pattern` is a :t:`range pattern` that uses obsolete
 syntax to express an :t:`inclusive range pattern`.
 
-:dp:`fls_ta0wa8ta9ol4`
 See :s:`ObsoleteRangePattern`.
-
-.. _fls_q47u2zq6clon:
 
 octal literal
 ^^^^^^^^^^^^^
 
-:dp:`fls_pf4341vnqiin`
 An :dt:`octal literal` is an :t:`integer literal` in base 8.
 
-:dp:`fls_8u0n6xu0mizm`
 See ``OctalLiteral.``
-
-.. _fls_pv4lok5qcn8y:
 
 operand
 ^^^^^^^
 
-:dp:`fls_3mnn1au9ob6q`
 An :dt:`operand` is an :t:`expression` nested within an expression.
 
-:dp:`fls_8299xfhdsd1`
 See :s:`Operand`.
-
-.. _fls_smk8mi72lt57:
 
 operator expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6ev01xwcfow1`
 An :dt:`operator expression` is an :t:`expression` that involves an operator.
 
-:dp:`fls_qdszbyeuo7w1`
 See :s:`OperatorExpression`.
-
-.. _fls_C5DiCsvsaBsj:
 
 opt-out trait bound
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wS4EzN0N1GDP`
 An :dt:`opt-out trait bound` is a :t:`trait bound` with :s:`Punctuation` ``?``
 that nullifies an implicitly added :t:`trait bound`.
 
 
-.. _fls_LnPDQW3bnNUw:
-
 or-pattern
 ^^^^^^^^^^
 
-:dp:`fls_LnPDQW3bnNUw`
 An :dt:`or-pattern` is a :t:`pattern` that matches on one of two or more :t:`[pattern-without-alternation]s` and or-s them using character 0x7C (vertical line, i.e. ``|``).
 
-:dp:`fls_urIJ5JNHLhm6`
 See :s:`Pattern`.
-
-.. _fls_gllzixm9yt9w:
 
 outer attribute
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_gffxnbilsqly`
 An :dt:`outer attribute` is an :t:`attribute` that applies to a subsequent
 :t:`item`.
 
-:dp:`fls_ty6ihy6x3kf`
 See :s:`OuterAttribute`.
-
-.. _fls_toncretg92qh:
 
 outer block doc
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_531ggn1f8f6u`
 An :dt:`outer block doc` is a :t:`block comment` that applies to a subsequent
 :t:`non-[comment]` :t:`construct`.
 
-:dp:`fls_ddy9a66tpytp`
 See :s:`OuterBlockDoc`.
-
-.. _fls_PuTD100sWO5N:
 
 outer doc comment
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mgSEUNUPcPBs`
 An :dt:`outer doc comment` is either an :t:`outer block doc` or an
 :t:`outer line doc`.
-
-.. _fls_eqjbv8sovvfl:
 
 outer line doc
 ^^^^^^^^^^^^^^
 
-:dp:`fls_m3u30fu8uac3`
 An :dt:`outer line doc` is a :t:`line comment` that applies to a subsequent
 :t:`non-[comment]` :t:`construct`.
 
-:dp:`fls_1ppwidw7szk5`
 See :s:`OuterLineDoc`.
-
-.. _fls_de935b1pzd28:
 
 outline module
 ^^^^^^^^^^^^^^
 
-:dp:`fls_xhe5gmr0r9zn`
 An :dt:`outline module` is a :t:`module` with an
 :s:`OutlineModuleSpecification`.
 
-:dp:`fls_wu5wqylzx9ke`
 See :s:`OutlineModuleSpecification`.
-
-.. _fls_5LhIr1kOIEO5:
 
 outlives bound
 ^^^^^^^^^^^^^^
 
-:dp:`fls_J5dt34II7Pm6`
 An :dt:`outlives bound` is a :t:`trait bound` which requires that a
 :t:`generic parameter` outlives a :t:`lifetime parameter`.
-
-.. _fls_XsGnaA47Nen0:
 
 output register
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_4METI8qE9JiY`
 An :dt:`output register` is a :t:`register` whose :t:`register name` is
 used in a :t:`register argument` subject to :t:`direction modifier` ``out``,
 ``lateout``, ``inout``, or ``inlateout``.
 
-.. _fls_t79aKPilX8jk:
-
 output register expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_w95YRZ4JjBxl`
 An :dt:`output register expression` is an :t:`expression` that is assigned the
 :t:`value` of a :t:`register`.
 
-:dp:`fls_8B3ldFZVy7PA`
 See :s:`OutputRegisterExpression`.
-
-.. _fls_nhamq7xtz384:
 
 overlap
 ^^^^^^^
 
-:dp:`fls_itkz9y19923k`
 Two :t:`[value]s` :dt:`overlap` when their memory locations overlap, or both
 values are elements of the same :t:`array`.
-
-.. _fls_ke52l9lsvyu2:
 
 owner
 ^^^^^
 
-:dp:`fls_7vwwhberexeb`
 An :dt:`owner` is a :t:`variable` that holds a :t:`value`.
-
-.. _fls_1gmetz8qtr0l:
 
 ownership
 ^^^^^^^^^
 
-:dp:`fls_tu4zt8twucsz`
 :dt:`Ownership` is a property of :t:`[value]s` that is central to the resource
 management model of Rust.
-
-.. _fls_wzpivxkhpln:
 
 panic
 ^^^^^
 
-:dp:`fls_t3kpbnmohtp6`
 A :dt:`panic` is an abnormal program state caused by invoking :t:`macro`
 :std:`core::panic`.
-
-.. _fls_fl56jfxbj0f:
 
 parenthesized expression
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_yu1x2rr7cewa`
 A :dt:`parenthesized expression` is an :t:`expression` that groups other
 expressions.
 
-:dp:`fls_p9exa6fpplfu`
 See :s:`ParenthesizedExpression`.
-
-.. _fls_ww6nyinsw1lr:
 
 parenthesized pattern
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_7j12dwsx9ghg`
 A :dt:`parenthesized pattern` is a :t:`pattern` that controls the precedence of
 its :t:`[subpattern]s`.
 
-:dp:`fls_rwt31e8m694i`
 See :s:`ParenthesizedPattern`.
-
-.. _fls_gilx8zikdq9k:
 
 parenthesized type
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_pamypc7t7l5n`
 A :dt:`parenthesized type` is a :t:`type` that disambiguates the interpretation
 of :t:`[lexical element]s`.
 
-:dp:`fls_lovkvqoni3xs`
 See :s:`ParenthesizedTypeSpecification`.
-
-.. _fls_fULM1oCKSakS:
 
 partially hygienic
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Qh8V0Y08dNoa`
 An :t:`identifier` is :dt:`partially hygienic` when it has
 :t:`mixed site hygiene`.
-
-.. _fls_wqbd5lxki2al:
 
 passing convention
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_eqgsg8j9btic`
 A :dt:`passing convention` is the mechanism that defines how a :t:`value` is
 transferred between :t:`[place]s`.
-
-.. _fls_9zl72vtkgkuo:
 
 path
 ^^^^
 
-:dp:`fls_u3jyud6mhy1f`
 A :dt:`path` is a sequence of :t:`[path segment]s` logically separated by
 :dt:`namespace qualifier` ``::`` that resolves to an :t:`entity`.
-
-.. _fls_1xdj34py8zc3:
 
 path expression
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_4ik66nmvx5hn`
 A :dt:`path expression` is a :t:`path` that acts as an :t:`expression`.
 
-:dp:`fls_3qjpjqm0legc`
 See :s:`PathExpression`.
-
-.. _fls_EIFtIeLGZNy5:
 
 path expression resolution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_WYcEVyc3SHuK`
 :dt:`Path expression resolution` is a form of :t:`path resolution` that applies
 to a :t:`path expression`.
-
-.. _fls_ptikwcw3b20l:
 
 path pattern
 ^^^^^^^^^^^^
 
-:dp:`fls_vacvk3t26ctg`
 A :dt:`path pattern` is a :t:`pattern` that matches a :t:`constant`, a
 :t:`unit enum variant`, or a :t:`unit struct constant` indicated by a
 :t:`path`.
 
-:dp:`fls_9fudbxoyq8k4`
 See :s:`PathPattern`.
-
-.. _fls_J8kiBhcawvnj:
 
 path resolution
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_uy9Ai9vwTkjB`
 :dt:`Path resolution` is a form of :t:`resolution` that applies to a :t:`path`.
-
-.. _fls_xb54s9cs7h08:
 
 path segment
 ^^^^^^^^^^^^
 
-:dp:`fls_gsumebjc2bsp`
 A :dt:`path segment` is a constituent of a :t:`path`.
 
-:dp:`fls_m067uq7fo66i`
 See :s:`PathSegment`, :s:`SimplePathSegment`, :s:`TypePathSegment`.
-
-.. _fls_uj1o721im5lb:
 
 pattern
 ^^^^^^^
 
-:dp:`fls_9wwt9k1xlm6n`
 A :dt:`pattern` is a :t:`construct` that matches a :t:`value` which satisfies
 all the criteria of the pattern.
 
-:dp:`fls_9va04w9jgdyp`
 See :s:`Pattern`.
-
-.. _fls_48mv0zecb0un:
 
 pattern matching
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_y3oputy9e0sz`
 :t:`Pattern matching` is the process of matching a :t:`pattern` against a :t:`value`.
-
-.. _fls_cptagvgpgnze:
 
 pattern-without-alternation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_brussjs3wo6r`
 A :dt:`pattern-without-alternation` is a :t:`pattern` that cannot be alternated.
 
-:dp:`fls_fmysn3eezr54`
 See :s:`PatternWithoutAlternation`.
-
-.. _fls_yeQOZKPoNzw3:
 
 pattern-without-range
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_LSEOvAwUM7g6`
 A :dt:`pattern-without-range` is a :t:`pattern-without-alternation` that
 excludes :t:`[range pattern]s`.
 
-:dp:`fls_Rj8ir4k0K811`
 See :s:`PatternWithoutRange`.
-
-.. _fls_5zjHBZMsCqJZ:
 
 place
 ^^^^^
 
-:dp:`fls_uCTiUBWHMPY9`
 A :dt:`place` is a location where a :t:`value` resides.
-
-.. _fls_7x6jhh0sz2f:
 
 place expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_z6mgu2mk142r`
 A :dt:`place expression` is an :t:`expression` that represents a memory
 location.
-
-.. _fls_tshbqttxdox1:
 
 place expression context
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_fqcx8suiy5k`
 A :dt:`place expression context` is a :t:`construct` that may evaluate its
 operand as a memory location.
-
-.. _fls_dr6wbsqjd2qm:
 
 plane
 ^^^^^
 
-:dp:`fls_x1wbguoqdsf9`
 In :t:`Unicode`, a :dt:`plane` is a continuous group of 65,536
 :t:`[code point]s`.
-
-.. _fls_HnJEHyUiTpb1:
 
 pointer
 ^^^^^^^
 
-:dp:`fls_DRjhMWo9mjoF`
 A :dt:`pointer` is a :t:`value` of a :t:`pointer type`.
-
-.. _fls_o5o1ssqqD7Jg:
 
 pointer type
 ^^^^^^^^^^^^
 
-:dp:`fls_F2dUxEa4nheL`
 A :dt:`pointer type` is a :t:`type` whose values indicate memory locations.
-
-.. _fls_Q0r8JkqAP6Of:
 
 positional register argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_GJd6i52P3KM3`
 A :dt:`positional register argument` is a :t:`register argument` whose
 configuration is not bound to an :t:`identifier`.
-
-.. _fls_ukvdoqo68y5b:
 
 precedence
 ^^^^^^^^^^
 
-:dp:`fls_sz93844rqc4r`
 :dt:`Precedence` is the order by which :t:`[expression]s` are evaluated in the
 presence of other expressions.
-
-.. _fls_8Gn72FJBarfb:
 
 prelude
 ^^^^^^^
 
-:dp:`fls_D0PJioOZjKNN`
 A :dt:`prelude` is a collection of :t:`entities <entity>` that are
 automatically brought :t:`in scope` of every :t:`module` in a :t:`crate`.
-
-.. _fls_AWySDxPgypiw:
 
 prelude entity
 ^^^^^^^^^^^^^^
 
-:dp:`fls_2lU7RUjzFlsz`
 A :dt:`prelude entity` is an :t:`entity` declared in a :t:`prelude`.
-
-.. _fls_FYn5JqPOhiIs:
 
 prelude name
 ^^^^^^^^^^^^
 
-:dp:`fls_6Jk7fUAK122A`
 A :dt:`prelude name` is a :t:`name` of a :t:`prelude entity`.
-
-.. _fls_fikexts17v7a:
 
 primitive representation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_bydly1rt63pf`
 :dt:`Primitive representation` is the :t:`type representation` of
 :t:`[integer type]s`.
-
-.. _fls_mk3sa7OvtJvB:
 
 principal trait
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_YtYOHoPaMPFX`
 The :dt:`principal trait` of :t:`trait object type` is its first :t:`trait bound`.
-
-.. _fls_v1u1mevpj0kj:
 
 private visibility
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_duop22hyaweq`
 :dt:`Private visibility` is a kind of :t:`visibility` that allows a :t:`name`
 to be referred to only by the current :t:`module` of the :t:`entity`, and its
 descendant :t:`[module]s`.
 
-.. _fls_kCA6SW8bUq5x:
-
 proc-macro crate
 ^^^^^^^^^^^^^^^^
 
-.. _fls_AjjdLZWiL9Tq:
-
-:dp:`fls_DfTszT1PjV7o`
 A :dt:`proc-macro crate` is a :t:`crate` whose :t:`crate type` is ``proc-macro``.
-
-.. _fls_sp5wdsxwmxf:
 
 procedural macro
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_u4utpx4zgund`
 A :dt:`procedural macro` is a :t:`macro` that encapsulates syntactic
 transformations in a :t:`function`.
-
-.. _fls_SIFecOZqloyx:
 
 program entry point
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_9m37hN9zgEQf`
 A :dt:`program entry point` is a :t:`function` that is invoked at the start of
 a Rust program.
-
-.. _fls_v2rjlovqsdyr:
 
 public visibility
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6cfxqtl921ko`
 :dt:`Public visibility` is a kind of :t:`visibility` that allows a :t:`name`
 to be referred to from arbitrary :t:`module` ``M`` as long as the ancestor
 :t:`[module]s` of the related :t:`entity` can be referred to from ``M``.
 
-.. _fls_hdwmw3jbwefi:
-
 punctuator
 ^^^^^^^^^^
 
-:dp:`fls_gwqgi0b7jxmu`
 A :dt:`punctuator` is a character or a sequence of characters in category
 :s:`Punctuation`.
-
-.. _fls_sgwvmnoio1ql:
 
 pure identifier
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_6pez8fyiew0k`
 A :dt:`pure identifier` is an :t:`identifier` that does not include
 :t:`[weak keyword]s`.
-
-.. _fls_O6CFtnpN3UEE:
 
 qualified path expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_wKAS6FxqGmTf`
 A :dt:`qualified path expression` is a :t:`path expression` that resolves
 through a :t:`qualified type`.
 
-:dp:`fls_MXxJn64eJpC5`
 See :s:`QualifiedPathExpression`.
-
-.. _fls_Qv0UvhSfwBuM:
 
 qualified type
 ^^^^^^^^^^^^^^
 
-:dp:`fls_e7YyZXOFo6ei`
 A :dt:`qualified type` is a :t:`type` that is restricted to a set of
 :t:`[implementation]s` that exhibit :t:`implementation conformance` to a
 :t:`qualifying trait`.
 
-:dp:`fls_a4heXjzO3jem`
 See :s:`QualifiedType`.
-
-.. _fls_koVlQq8aPdPv:
 
 qualified type path
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_S0QT9ib38i8E`
 A :dt:`qualified type path` is a :t:`type path` that resolves through a
 :t:`qualified type`.
 
-:dp:`fls_RR8fFLD7Rxlt`
 See :s:`QualifiedTypePath`.
-
-.. _fls_B0m82A8jIerQ:
 
 qualifying trait
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_zKY1dWBMrqXZ`
 A :dt:`qualifying trait` is a :t:`trait` that imposes a restriction on a
 :t:`qualified type`.
 
-:dp:`fls_z6OeUWBnec90`
 See :s:`QualifyingTrait`.
-
-.. _fls_tbvugpuvcluj:
 
 range expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_bffrbucfwu7`
 A :dt:`range expression` is an :t:`expression` that constructs a range.
 
-:dp:`fls_1jk43yvxa8ks`
 See :s:`RangeExpression`.
-
-.. _fls_mdvdxr6u13fw:
 
 range expression high bound
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_c70pj8w15nmc`
 A :dt:`range expression high bound` is an :t:`operand` that specifies the end
 of a range.
 
-:dp:`fls_yxem0ckicxav`
 See :s:`RangeExpressionHighBound`.
-
-.. _fls_smvgd160eynr:
 
 range expression low bound
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_t10o1p950u00`
 A :dt:`range expression low bound` is an :t:`operand` that specifies the start
 of a range.
 
-:dp:`fls_vmb2z7oh6gzm`
 See :s:`RangeExpressionLowBound`.
-
-.. _fls_6pxg401r6juc:
 
 range pattern
 ^^^^^^^^^^^^^
 
-:dp:`fls_vf42zdyq23lc`
 A :dt:`range pattern` is a :t:`pattern` that matches :t:`[value]s` which fall
 within a range.
 
-:dp:`fls_r36uf3y2denr`
 See ``RangePattern``.
-
-.. _fls_3ls9xlgt8ei1:
 
 range pattern bound
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_l9xq96bjs4o2`
 A :dt:`range pattern bound` is a constraint on the range of a
 :t:`range pattern`.
 
-:dp:`fls_80736cs3axo4`
 See :s:`RangePatternBound`.
-
-.. _fls_y4rv5cbowvwg:
 
 range pattern high bound
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_arp7y7yme7yp`
 A :dt:`range pattern high bound` is a :t:`range pattern bound` that specifies
 the end of a range.
 
-:dp:`fls_dnwqcswftw71`
 See :s:`RangePatternHighBound`.
-
-.. _fls_laev4lmmv0cw:
 
 range pattern low bound
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rt7q0msh3op4`
 A :dt:`range pattern low bound` is a :t:`range pattern bound` that specifies
 the start of a range.
 
-:dp:`fls_j695o93wsu3i`
 See :s:`RangePatternLowBound`.
-
-.. _fls_iqpxlg7w3cvf:
 
 range-from expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6enyv2oa4abq`
 A :dt:`range-from expression` is a :t:`range expression` that specifies an
 included :t:`range expression low bound`.
 
-:dp:`fls_e1smn0b478ik`
 See :s:`RangeFromExpression`.
-
-.. _fls_125h4p4zt86q:
 
 range-from-to expression
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_nzf6y64jz83f`
 A :dt:`range-from-to expression` is a :t:`range expression` that specifies an
 included :t:`range expression low bound` and an excluded
 :t:`range expression high bound`.
 
-:dp:`fls_mjbxfjulryt`
 See :s:`RangeFromToExpression`.
-
-.. _fls_8z8nrblarxrv:
 
 range-full expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6mchm7kb7i41`
 A :dt:`range-full expression` is a :t:`range expression` that covers the whole
 range of a :t:`type`.
 
-:dp:`fls_u7kd8w5g2icd`
 See :s:`RangeFullExpression`.
-
-.. _fls_tie80ejz8s19:
 
 range-inclusive expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_9vja0wev84a7`
 A :dt:`range-inclusive expression` is a :t:`range expression` that specifies an
 included :t:`range expression low bound` and an included
 :t:`range expression high bound`.
 
-:dp:`fls_lpcsb8dtldk3`
 See :s:`RangeInclusiveExpression`.
-
-.. _fls_etvgkb8zcfpd:
 
 range-to expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_urnfp1j9d5v4`
 A :dt:`range-to expression` is a :t:`range expression` that specifies an
 excluded :t:`range expression high bound`.
 
-:dp:`fls_lft9cd7h8cfv`
 See :s:`RangeToExpression`.
-
-.. _fls_ap5754dfltt5:
 
 range-to-inclusive expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_t4fjanjvkd69`
 A :dt:`range-to-inclusive expression` is a :t:`range expression` that specifies
 an included :t:`range expression high bound`.
 
-:dp:`fls_krei7lc6lo8q`
 See :s:`RangeToInclusiveExpression`.
-
-.. _fls_YLhE2qpzYXRK:
 
 raw borrow expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Fe39wLb0vvEg`
 A :dt:`raw borrow expression` is an :t:`expression` that creates a :t:`raw pointer` to the memory location of its :t:`operand` without incurring a :t:`borrow`.
 
-:dp:`fls_I71jq8BGyLqi`
 See :s:`RawBorrowExpression`.
-
-.. _fls_ipeh92kh17ze:
 
 raw byte string literal
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8v5k3wemy4tl`
 A :dt:`raw byte string literal` is a :t:`simple byte string literal` that does
 not recognize :t:`[escaped character]s`.
 
-:dp:`fls_5x71i3ay3na2`
 See :s:`RawByteStringLiteral`.
-
-.. _fls_yGGvg3e0nPOh:
 
 raw c string literal
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_qhWBzqoYZL0e`
 A :dt:`raw c string literal` is a :t:`simple c string literal` that does not
 recognize :t:`[escaped character]s`.
 
-:dp:`fls_WpFJyq6q4k6E`
 See :s:`RawCStringLiteral`.
-
-.. _fls_uv4dyt4gi32x:
 
 raw pointer
 ^^^^^^^^^^^
 
-:dp:`fls_rbdilcmt2cns`
 A :dt:`raw pointer` is a pointer of a :t:`raw pointer type`.
-
-.. _fls_9los8hwh60z0:
 
 raw pointer type
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_wspawcoqxfbh`
 A :dt:`raw pointer type` is an :t:`indirection type` without safety and
 liveness guarantees.
 
-:dp:`fls_ctksliaxhzo9`
 See :s:`RawPointerTypeSpecification`.
-
-.. _fls_echjohx6fjc:
 
 raw string literal
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_48t4v316951j`
 A :dt:`raw string literal` is a :t:`simple string literal` that does not
 recognize :t:`[escaped character]s`.
 
-:dp:`fls_26ol7lrnux94`
 See :s:`RawStringLiteral`.
-
-.. _fls_sAe1HaaVSPvP:
 
 reachable control flow path
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_IxrvzuBg8j3E`
 A :dt:`reachable control flow path` is a control flow path that can be
 taken by the execution of a program between two given points in the program.
-
-.. _fls_nfb3ciarl50w:
 
 receiver operand
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_odbg4bizvqxq`
 A :dt:`receiver operand` is an :t:`operand` that denotes the :t:`value` whose
 :t:`method` is being invoked by a :t:`method call expression`.
 
-:dp:`fls_4rme1x6romeg`
 See :s:`ReceiverOperand`.
-
-.. _fls_Kpkm0J40xq5J:
 
 receiver type
 ^^^^^^^^^^^^^
 
-:dp:`fls_vgQmMlpFas5t`
 A :dt:`receiver type` is the :t:`type` of a :t:`receiver operand`.
-
-.. _fls_nG6ikjLsCW7m:
 
 record enum variant
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_NWyvPQmOIjo2`
 A :dt:`record enum variant` is an :t:`enum variant` with a
 :s:`RecordStructFieldList`.
-
-.. _fls_jdd6h8pdp30x:
 
 record struct
 ^^^^^^^^^^^^^
 
-:dp:`fls_qyd7kqnpjs2`
 A :dt:`record struct` is a :t:`struct` with a :s:`RecordStructFieldList`.
 
-:dp:`fls_rqs5rdnhkwnx`
 See :s:`RecordStructDeclaration`.
-
-.. _fls_hzkwzbk5wp54:
 
 record struct field
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lb0t10evec6z`
 A :dt:`record struct field` is a :t:`field` of a :t:`record struct type`.
 
-:dp:`fls_bjwmhxf3ae14`
 See :s:`RecordStructField`.
-
-.. _fls_at2caaqlpva1:
 
 record struct pattern
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_q7njznxhmmw`
 A :dt:`record struct pattern` is a :t:`pattern` that matches a
 :t:`enum variant value`, a :t:`struct value`, or a :t:`union value`.
 
-:dp:`fls_viwieu1p3hds`
 See :s:`RecordStructPattern`.
-
-.. _fls_uthd12hz3h4v:
 
 record struct type
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mgrz3o51gbis`
 A :dt:`record struct type` is the :t:`type` of a :t:`record struct`.
-
-.. _fls_cPs5C1chWmce:
 
 record struct value
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_SMBIc0JMck1H`
 A :dt:`record struct value` is a :t:`value` of a :t:`record struct type`.
-
-.. _fls_94fkxohlnq9i:
 
 recursive type
 ^^^^^^^^^^^^^^
 
-:dp:`fls_2t8qom6dhcjb`
 A :dt:`recursive type` is a :t:`type` that may define other types within its
 :t:`type specification`.
-
-.. _fls_onv3cs5tckgo:
 
 reference
 ^^^^^^^^^
 
-:dp:`fls_s82y4hsuytiq`
 A :dt:`reference` is a :t:`value` of a :t:`reference type`.
-
-.. _fls_1XGsXRZIFnqL:
 
 reference identifier pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_jQs6oJ4RFBPN`
 A :dt:`reference identifier pattern` is an :t:`identifier pattern` with
 :t:`keyword` ``ref``.
-
-.. _fls_kiy6b1wbn0a3:
 
 reference pattern
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ebshqnhmwgow`
 A :dt:`reference pattern` is a :t:`pattern` that dereferences a :t:`pointer`
 that is being matched.
 
-:dp:`fls_rghv5drrqxs1`
 See :s:`ReferencePattern`.
-
-.. _fls_uw32xmrfgzcd:
 
 reference type
 ^^^^^^^^^^^^^^
 
-:dp:`fls_l3knopsdlyf2`
 A :dt:`reference type` is an :t:`indirection type` with :t:`ownership`.
 
-:dp:`fls_jzjatdpxqt9u`
 See :s:`ReferenceTypeSpecification`.
-
-.. _fls_h8x0u32wfz8v:
 
 referent
 ^^^^^^^^
 
-:dp:`fls_78ipj8avpwzl`
 A :dt:`referent` is the :t:`value` pointed-to by a :t:`reference`.
-
-.. _fls_bkwy183h9ygt:
 
 refutability
 ^^^^^^^^^^^^
 
-:dp:`fls_gzjrfx19fg40`
 :dt:`Refutability` is a property of :t:`[pattern]s` that expresses the ability
 to match all possible :t:`[value]s` of a :t:`type`.
-
-.. _fls_v99joc4m6cup:
 
 refutable constant
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mc6hsomq08uu`
 A :dt:`refutable constant` is a :t:`constant` of a :t:`refutable type`.
-
-.. _fls_srdcx5oi4dcp:
 
 refutable pattern
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_re7qz78koman`
 A :dt:`refutable pattern` is a :t:`pattern` that has a possibility of not
 matching the :t:`value` it is being matched against.
-
-.. _fls_dkq1h6p9yaar:
 
 refutable type
 ^^^^^^^^^^^^^^
 
-:dp:`fls_l2yz6jeehm52`
 A :dt:`refutable type` is a :t:`type` that has more than one :t:`value`.
-
-.. _fls_T84qaJMZzMbb:
 
 register
 ^^^^^^^^
 
-:dp:`fls_fVdSybu8DW8w`
 A :dt:`register` is a hardware component capable of holding data that can be
 read and written.
-
-.. _fls_ISWWmgKjfYwt:
 
 register argument
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rNoFdCKbVmRC`
 A :dt:`register argument` is a :t:`construct` that configures the input
 and output of a :t:`register`, and optionally binds the configuration to an
 :t:`identifier`.
 
-:dp:`fls_aof7O9XREo2S`
 See :s:`RegisterArgument`.
-
-.. _fls_2qKUiHcfmZQ6:
 
 register class
 ^^^^^^^^^^^^^^
 
-:dp:`fls_2H0OYS733VJl`
 A :dt:`register class` represents a set of :t:`[register]s`.
-
-.. _fls_8gC17CgCS9n1:
 
 register class argument
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ksLXAyPLx9IL`
 A :dt:`register class argument` is a :t:`register argument` that uses a
 :t:`register class name`.
-
-.. _fls_xZTkANlRsKRt:
 
 register class name
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_QsSFoL0UyRRB`
 A :dt:`register class name` is a target-specific string that identifies a
 :t:`register class`.
 
-:dp:`fls_Y1ZpiFAV2c1A`
 See :s:`RegisterClassName`.
-
-.. _fls_7KIReJZLKdeK:
 
 register expression
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_2cVy6XfOQ4QG`
 A :dt:`register expression` is either an :t:`input-output register expression`
 or a :t:`simple register expression`.
 
-:dp:`fls_YEzo09cqWUUy`
 See :s:`RegisterExpression`.
-
-.. _fls_kbBK666iBS2X:
 
 register name
 ^^^^^^^^^^^^^
 
-:dp:`fls_U5r8Ypnjah5E`
 A :dt:`register name` is either the :t:`explicit register name` of a
 :t:`register`, or the :t:`register class name` of the :t:`register class` a
 :t:`register` belongs to.
 
-:dp:`fls_WeyiFrnGgWPn`
 See :s:`RegisterName`.
-
-.. _fls_foh6xELWBsY9:
 
 register parameter
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_JicHMIj5dlxJ`
 A :dt:`register parameter` is a substring delimited by characters 0x7B (left
 curly bracket) and 0x7D (right curly bracket) that is substituted with a
 :t:`register argument` in an :t:`assembly instruction`.
 
-.. _fls_NDpKXnlmnN7M:
-
 register parameter modifier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8BdOnxHZS0Qi`
 A :dt:`register parameter modifier` is a substring that starts with character
 0x3A (colon), follows a :t:`register parameter`, and changes the formatting of
 the related :t:`register parameter`.
 
-.. _fls_JnhUWipah0nO:
-
 remainder assignment
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_58eDC2XtQcaR`
 For :dt:`remainder assignment`, see :t:`remainder assignment expression`.
-
-.. _fls_mio7pagghcks:
 
 remainder assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_en7ytqvefw7j`
 A :dt:`remainder assignment expression` is a
 :t:`compound assignment expression` that uses remainder division.
 
-:dp:`fls_rkk80quk8uzc`
 See :s:`RemainderAssignmentExpression`.
-
-.. _fls_f15h4919ln3k:
 
 remainder expression
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_l6muwnclm1do`
 A :dt:`remainder expression` is an :t:`arithmetic expression` that uses
 remainder division.
 
-:dp:`fls_h98qlby2uiru`
 See :s:`RemainderExpression`.
-
-.. _fls_8ibsdx4dx6s7:
 
 renaming
 ^^^^^^^^
 
-:dp:`fls_cp8u9kq44o8a`
 A :dt:`renaming` provides an alternative :t:`name` for an existing name.
 
-:dp:`fls_8inznqig2ibr`
 See :s:`Renaming`.
-
-.. _fls_b35oy3nnzixm:
 
 repeat operand
 ^^^^^^^^^^^^^^
 
-:dp:`fls_ol2y1og2jwss`
 A :dt:`repeat operand` is an :t:`operand` that specifies the element being
 repeated in an :t:`array repetition constructor`.
 
-:dp:`fls_r4acyux78txu`
 See :s:`RepeatOperand`.
-
-.. _fls_r2yjjhrvr9qi:
 
 repetition operator
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_67907pk7uogl`
 A :dt:`repetition operator` is a :t:`construct` that indicates the number
 of times a :t:`macro repetition in matching` or a
 :t:`macro repetition in transcription` can be repeated.
 
-:dp:`fls_hiasmmpr2jks`
 See :s:`MacroRepetitionOperator`.
-
-.. _fls_o34kkn5pi0sh:
 
 representation
 ^^^^^^^^^^^^^^
 
-:dp:`fls_69j7pq2o1iu`
 See :t:`type representation`.
-
-.. _fls_TSbBt6WzropN:
 
 representation modifier
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_BCvXL7HkXqdZ`
 A :dt:`representation modifier` is a :t:`construct` that modifies the
 :t:`alignment` of a :t:`type`.
 
-:dp:`fls_TAVyjj66UBUo`
 See :s:`Alignment`.
-
-.. _fls_x7yd6o4akrrg:
 
 reserved keyword
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_b67hj7fdbq4s`
 A :dt:`reserved keyword` is a :t:`keyword` that is not yet in use.
 
-:dp:`fls_hp9iqdrkt0cg`
 See :s:`ReservedKeyword`.
-
-.. _fls_O5iuGATZgyBu:
 
 resolution
 ^^^^^^^^^^
 
-:dp:`fls_PQjEvLs5cE4y`
 :dt:`Resolution` is the process of finding a unique interpretation for a
 :t:`field access expression`, a :t:`method call expression`, or a :t:`path`.
-
-.. _fls_uuo1qvrz1i0k:
 
 rest pattern
 ^^^^^^^^^^^^
 
-:dp:`fls_xngp3h1znw9o`
 A :dt:`rest pattern` is a :t:`pattern` that matches zero or more elements that
 have not already been matched.
 
-:dp:`fls_rnmhg04u0oga`
 See :s:`RestPattern`.
-
-.. _fls_7tl9qo8yj8xh:
 
 return expression
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_vnupfc6s0s7b`
 A :dt:`return expression` is an :t:`expression` that optionally yields a
 :t:`value` and causes control flow to return to the caller.
 
-:dp:`fls_phd8zrsyuzu7`
 See :s:`ReturnExpression`.
-
-.. _fls_b8dbm1bs65kw:
 
 return type
 ^^^^^^^^^^^
 
-:dp:`fls_cwucgbmmhnnm`
 A :dt:`return type` is the :t:`type` of the result a :t:`function` returns.
 
-:dp:`fls_utuprsem6n58`
 See :s:`ReturnType`.
-
-.. _fls_76o7m8vny72n:
 
 right operand
 ^^^^^^^^^^^^^
 
-:dp:`fls_e1j9s4odze9b`
 A :dt:`right operand` is an :t:`operand` that appears on the right-hand side of
 a :t:`binary operator`.
 
-:dp:`fls_hq7x1t5dmdlp`
 See :s:`RightOperand`.
-
-.. _fls_9u67noriaxfe:
 
 rule matching
 ^^^^^^^^^^^^^
 
-:dp:`fls_dux9js5oixjd`
 :dt:`Rule matching` is the process of consuming a :s:`TokenTree` in an attempt
 to fully satisfy the :t:`macro matcher` of a :t:`macro rule` that belongs to a
 resolved :t:`declarative macro`.
 
-.. _fls_fki32ns69q4j:
-
 rustc
 ^^^^^
 
-:dp:`fls_zdgbeixirjfm`
 :dt:`rustc` is a compiler that implements the FLS.
-
-.. _fls_Q4MRIo7cWv5K:
 
 safety invariant
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_wRZfAmTmMGTX`
 A :dt:`safety invariant` is an invariant that when violated may result in
 :t:`undefined behavior`.
-
-.. _fls_XeMNghZZOBqL:
 
 scalar type
 ^^^^^^^^^^^
 
-:dp:`fls_GgBqFW2NywoA`
 A :dt:`scalar type` is either a :c:`bool` :t:`type`, a :c:`char` :t:`type`, or
 a :t:`numeric type`.
-
-.. _fls_fj8mdxi967px:
 
 scope
 ^^^^^
 
-:dp:`fls_fachaj550cq1`
 A :dt:`scope` is a region of program text where a :t:`name` can be referred to.
-
-.. _fls_xZUiNkBN5e00:
 
 scope hierarchy
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_Spcc3L9X939d`
 The :dt:`scope hierarchy` reflects the nesting of :t:`[scope]s` as introduced
 by :t:`[scoping construct]s`.
-
-.. _fls_rfk06mm3pdxg:
 
 selected field
 ^^^^^^^^^^^^^^
 
-:dp:`fls_8otlvwlqrd4e`
 A :dt:`selected field` is a :t:`field` that is selected by a
 :t:`field access expression`.
-
-.. _fls_9o2hcy6t7dac:
 
 Self
 ^^^^
 
-:dp:`fls_q6whqbfusswf`
 :dc:`Self` is either an implicit :t:`type parameter` in :t:`[trait]s` or an
 implicit :t:`type alias` in :t:`[implementation]s`. :c:`Self` refers to the
 :t:`type` that implements a :t:`trait`.
 
-.. _fls_6wjlbzmlx9n4:
-
 self parameter
 ^^^^^^^^^^^^^^
 
-:dp:`fls_ksne48eip15`
 A :dt:`self parameter` is a :t:`function parameter` expressed by :t:`keyword`
 ``self``.
-
-.. _fls_jq213cesxhyp:
 
 self public modifier
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ln3bzqgctfym`
 A :dt:`self public modifier` is a :t:`visibility modifier` that grants a
 :t:`name` :t:`private visibility`.
 
-:dp:`fls_21cvbfjpckkt`
 See :s:`SelfPublicModifier`.
-
-.. _fls_exMZlNMxQvP7:
 
 Self scope
 ^^^^^^^^^^
 
-:dp:`fls_pSvqWGRmFmH0`
 A :dt:`Self scope` is a :t:`scope` for :c:`Self`.
-
-.. _fls_8spw41g0dbqw:
 
 send type
 ^^^^^^^^^
 
-:dp:`fls_qfkng98dw6yy`
 A :dt:`send type` is a :t:`type` that implements the :std:`core::marker::Send`
 :t:`trait`.
-
-.. _fls_at8q1svh3isg:
 
 separator
 ^^^^^^^^^
 
-:dp:`fls_128xny4qfcj5`
 A :dt:`separator` is a character or a string that separates adjacent
 :t:`[lexical element]s`.
-
-.. _fls_rtgis2k7by2r:
 
 sequence type
 ^^^^^^^^^^^^^
 
-:dp:`fls_lk1oslxh8h9p`
 A :dt:`sequence type` represents a sequence of elements.
-
-.. _fls_HUklMSWzx8Mg:
 
 shadowing
 ^^^^^^^^^
 
-:dp:`fls_li3NXOPEH9cL`
 :dt:`Shadowing` is a property of :t:`[name]s`. A :t:`name` is said to be
 :dt:`shadowed` when another :t:`name` with the same characters is introduced
 in the same :t:`scope` within the same :t:`namespace`, effectively hiding it.
 
-.. _fls_c9xwhhg639u5:
-
 shared borrow
 ^^^^^^^^^^^^^
 
-:dp:`fls_gmbskxin90zi`
 A :dt:`shared borrow` is a :t:`borrow` produced by evaluating an
 :t:`immutable borrow expression`.
-
-.. _fls_18xazs7sp4:
 
 shared reference
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_cspa4c5mscnw`
 A :dt:`shared reference` is a :t:`value` of a :t:`shared reference type`.
-
-.. _fls_antrblstppyf:
 
 shared reference type
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_8z9wb3eu5yp1`
 A :dt:`shared reference type` is a :t:`reference type` not subject to
 :t:`keyword` ``mut``.
-
-.. _fls_o8EVuKgr0Y98:
 
 shift left assignment
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6adWrtvab6Tw`
 For :dt:`shift left assignment`, see :t:`shift left assignment expression`.
-
-.. _fls_29n0oe4d7lwa:
 
 shift left assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_j15ke2p8cjfp`
 A :dt:`shift left assignment expression` is a
 :t:`compound assignment expression` that uses bit shift left arithmetic.
 
-:dp:`fls_ozu74fsakomn`
 See :s:`ShiftLeftAssignmentExpression`.
-
-.. _fls_sru4wi5jomoe:
 
 shift left expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_phiv6k4emauc`
 A :dt:`shift left expression` is a :t:`bit expression` that uses bit shift left
 arithmetic.
 
-:dp:`fls_56lu9kenzig9`
 See :s:`ShiftLeftExpression`.
-
-.. _fls_V5LMAe8ijiMQ:
 
 shift right assignment
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_XuwcHjwHdyA8`
 For :dt:`shift right assignment`, see :t:`shift right assignment expression`.
-
-.. _fls_cqfzbsasnd1t:
 
 shift right assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_1jpnp7hatlmu`
 A :dt:`shift right assignment expression` is a
 :t:`compound assignment expression` that uses bit shift right arithmetic.
 
-:dp:`fls_naqzlebew1uf`
 See :s:`ShiftRightAssignmentExpression`.
-
-.. _fls_dj6epbraptqn:
 
 shift right expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_j6itily0u0k9`
 A :dt:`shift right expression` is a :t:`bit expression` that uses bit shift
 right arithmetic.
 
-:dp:`fls_ex1mopil8w1p`
 See :s:`ShiftRightExpression`.
-
-.. _fls_5sxhx0w3d63z:
 
 shorthand deconstructor
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_22yxrde244w8`
 A :dt:`shorthand deconstructor` is a :t:`construct` that matches the :t:`name`
 of a :t:`field` and binds the :t:`value` of the matched :t:`field` to a
 :t:`binding`.
 
-:dp:`fls_rlo4237bgbwt`
 See :s:`ShorthandDeconstructor`.
-
-.. _fls_oa4p10yles30:
 
 shorthand initializer
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_bgxxg48snck1`
 A :dt:`shorthand initializer` is a :t:`construct` that specifies the :t:`name`
 of a :t:`field` in a :t:`struct expression`.
 
-:dp:`fls_qc08ydgmqudi`
 See :s:`ShorthandInitializer`.
-
-.. _fls_nmw95nc951iu:
 
 signed integer type
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_vcronf7l2bhy`
 A :dt:`signed integer type` is an :t:`integer type` whose :t:`[value]s` denote
 negative whole numbers, zero, and positive whole numbers.
-
-.. _fls_4GvXiDfcPlRD:
 
 simple byte string literal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_XpbU4Up0Aza8`
 A :dt:`simple byte string literal` is a :t:`byte string literal` that consists
 of multiple :s:`[AsciiCharacter]s`.
 
-:dp:`fls_OfI70zK68TnQ`
 See :s:`SimpleByteStringLiteral`.
-
-.. _fls_fx2hhB0HHSUG:
 
 simple c string literal
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_qoHXrmds9SgI`
 A :dt:`simple c string literal` is any :t:`Unicode` character except characters
 0x0D (carriage return), 0x22 (quotation mark), 0x5C (reverse solidus) and 0x00
 (null byte).
 
-:dp:`fls_ggm5FNUqg9EY`
 See :s:`SimpleCStringLiteral`.
-
-.. _fls_6mcm7xdcyn40:
 
 simple import
 ^^^^^^^^^^^^^
 
-:dp:`fls_jrlzpoauui9g`
 A :dt:`simple import` is a :t:`use import` that binds a :t:`simple path` to a
 local :t:`name` by using an optional :t:`renaming`.
 
-:dp:`fls_ta5t4h25unsw`
 See :s:`SimpleImport`.
-
-.. _fls_o5kv9lrtz4fq:
 
 simple path
 ^^^^^^^^^^^
 
-:dp:`fls_db91duoug4eb`
 A :dt:`simple path` is a :t:`path` whose :t:`[path segment]s` consist of either
 :t:`[identifier]s` or certain :t:`[keyword]s`.
 
-:dp:`fls_cm7ysyfrdwom`
 See :s:`SimplePath`.
-
-.. _fls_23G6TAntJXqa:
 
 simple path prefix
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ijc2yHQuIltY`
 A :dt:`simple path prefix` is the leading :t:`simple path` of a
 :t:`glob import` or a :t:`nesting import`.
 
-:dp:`fls_ImHceyHhK6OZ`
 See :s:`SimplePathPrefix`.
-
-.. _fls_sgy9q06yt6cl:
 
 simple path public modifier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_mby9r0jm6uyv`
 A :dt:`simple path public modifier` is a :t:`visibility modifier` that grants a
 :t:`name` :t:`public visibility` within the provided :t:`simple path` only.
 
-:dp:`fls_mud4hw74kuh6`
 See :s:`SimplePathPublicModifier`.
-
-.. _fls_gT5rZ4qC3pHo:
 
 simple path resolution
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_CQlepoN6PmKq`
 :dt:`Simple path resolution` is a kind of :t:`path resolution` that applies to
 a :t:`simple path`.
-
-.. _fls_k5uqt5oj7wvl:
 
 simple public modifier
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ce1ounn1g68`
 A :dt:`simple public modifier` is a :t:`visibility modifier` that grants a
 :t:`name` :t:`public visibility`.
 
-:dp:`fls_rd68vm2f2qy5`
 See :s:`SelfPublicModifier`.
-
-.. _fls_JDB3eBO0DY4o:
 
 simple register expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_4Yp4R7gXucL2`
 A :dt:`simple register expression` is either an :t:`expression` or an
 :t:`underscore expression`.
 
-:dp:`fls_kKaqHDxPTTUC`
 See :s:`SimpleRegisterExpression`.
-
-.. _fls_dpod2gc7a0u:
 
 simple string literal
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_p6qyyptz8w8w`
 A :dt:`simple string literal` is a :t:`string literal` where the characters are
 :t:`Unicode` characters.
 
-:dp:`fls_osj0c4dmr6e0`
 See :s:`SimpleStringLiteral`.
-
-.. _fls_JS91BDzd03Qj:
 
 single segment path
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Hun5BCZsqd6k`
 A :dt:`single segment path` is a :t:`path` consisting of exactly one
 :t:`path segment`.
-
-.. _fls_oy5xy5pm1enx:
 
 size
 ^^^^
 
-:dp:`fls_3obnilqhkjux`
 The :dt:`size` of a :t:`value` is the offset in bytes between successive
 elements in an :t:`array type` with the same :t:`element type`, including any
 padding for :t:`alignment`.
 
-.. _fls_2y5oyon3y1za:
-
 size operand
 ^^^^^^^^^^^^
 
-:dp:`fls_srajsqi5i3py`
 A :dt:`size operand` is an :t:`operand` that specifies the size of an
 :t:`array` or an :t:`array type`.
 
-:dp:`fls_228ioayvdguv`
 See :s:`SizeOperand`.
-
-.. _fls_oiaoWEQQDE7I:
 
 sized type
 ^^^^^^^^^^
 
-:dp:`fls_pwcgsRCNSwKn`
 A :dt:`sized type` is a :t:`type` with statically known size.
-
-.. _fls_srkftses9sxn:
 
 slice
 ^^^^^
 
-:dp:`fls_p1sv01ml2ark`
 A :dt:`slice` is a :t:`value` of a :t:`slice type`.
-
-.. _fls_1s3a31o9zx1a:
 
 slice pattern
 ^^^^^^^^^^^^^
 
-:dp:`fls_7613qu4igwiw`
 A :dt:`slice pattern` is a :t:`pattern` that matches :t:`[array]s` of fixed
 size and :t:`[slice]s` of dynamic size.
 
-:dp:`fls_3qey00280x27`
 See :s:`SlicePattern`.
-
-.. _fls_x3kr88m5gvwv:
 
 slice type
 ^^^^^^^^^^
 
-:dp:`fls_bvpszep1w90g`
 A :dt:`slice type` is a :t:`sequence type` that provides a view into a sequence
 of elements.
 
-:dp:`fls_y7gscwf29htg`
 See :s:`SliceTypeSpecification`.
-
-.. _fls_wlwwxzpnhk6i:
 
 source file
 ^^^^^^^^^^^
 
-:dp:`fls_nh737q4mn27u`
 A :dt:`source file` contains the program text of :t:`[inner attribute]s`,
 :t:`[inner doc comment]s`, and :t:`[item]s`.
 
-:dp:`fls_zgh1m5357ex1`
 See :s:`SourceFile`.
-
-.. _fls_e7cvo0usw86i:
 
 statement
 ^^^^^^^^^
 
-:dp:`fls_faijgwg4lhp9`
 A :dt:`statement` is a component of a block expression.
 
-:dp:`fls_th7edvxml3mn`
 See :s:`Statement`.
-
-.. _fls_tpazbmuq9hag:
 
 static
 ^^^^^^
 
-:dp:`fls_srx4v1e20yxa`
 A :dt:`static` is a :t:`value` that is associated with a specific memory
 location.
 
-:dp:`fls_1b7gpk8e98pw`
 See :s:`StaticDeclaration`.
-
-.. _fls_x331kxllyzim:
 
 static initializer
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_6jjbfni87tax`
 A :dt:`static initializer` is a :t:`construct` that provides the :t:`value` of
 its related :t:`static`.
 
-:dp:`fls_igbl5uv0dlhl`
 See :s:`StaticInitializer`.
-
-.. _fls_jCqiKgW9g8n5:
 
 static lifetime elision
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_NbVewjYRnQPF`
 :dt:`Static lifetime elision` is a form of :t:`lifetime elision` that applies
 to :t:`[constant]s` and :t:`[static]s`.
-
-.. _fls_1ricdj86o457:
 
 str
 ^^^
 
-:dp:`fls_6977zxb0resa`
 :dc:`str` is a :t:`sequence type` that represents a :t:`slice` of 8-bit
 unsigned bytes.
-
-.. _fls_bzhaq3q378ay:
 
 strict keyword
 ^^^^^^^^^^^^^^
 
-:dp:`fls_hza9spr6behn`
 A :dt:`strict keyword` is a :t:`keyword` that always holds its special meaning.
 
-:dp:`fls_67pzayd9qzzs`
 See :s:`StrictKeyword`.
-
-.. _fls_cck2tmyzmpja:
 
 string literal
 ^^^^^^^^^^^^^^
 
-:dp:`fls_dphk5br0ag35`
 A :dt:`string literal` is a :t:`literal` that consists of multiple characters.
 
-:dp:`fls_z0t3ae24h5h5`
 See :s:`StringLiteral`.
-
-.. _fls_yphnf56fa58r:
 
 struct
 ^^^^^^
 
-:dp:`fls_rufylj7qxs1w`
 A :dt:`struct` is an :t:`item` that declares a :t:`struct type`.
-
-.. _fls_dxfyejkbiz3p:
 
 struct expression
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_m8n9e0sxyb95`
 A :dt:`struct expression` is an :t:`expression` that constructs an
 :t:`enum value`, a :t:`struct value`, or a :t:`union value`.
 
-:dp:`fls_odm68rhu2j1`
 See :s:`StructExpression`.
-
-.. _fls_OT6dJ7CWkSTG:
 
 struct field
 ^^^^^^^^^^^^
 
-:dp:`fls_8Z9YWMnrHXJS`
 A :dt:`struct field` is a :t:`field` of a :t:`struct type`.
-
-.. _fls_ook43xes5t34:
 
 struct pattern
 ^^^^^^^^^^^^^^
 
-:dp:`fls_xbtoiwegp8gu`
 A :dt:`struct pattern` is a :t:`pattern` that matches an :t:`enum value`, a
 :t:`struct value`, or a :t:`union value`.
 
-:dp:`fls_pn8e50ep2fln`
 See :s:`StructPattern`.
-
-.. _fls_pzj88ust6qrq:
 
 struct type
 ^^^^^^^^^^^
 
-:dp:`fls_7v4dhh3nl8h9`
 A :dt:`struct type` is an :t:`abstract data type` that is a product of other
 :t:`[type]s`.
 
-:dp:`fls_dhlww4yrnb2v`
 See :s:`StructDeclaration`.
 
-
-.. _fls_GOnQHAsYw1oi:
 
 struct value
 ^^^^^^^^^^^^
 
-:dp:`fls_YmZfW9kWlbIX`
 A :dt:`struct value` is a :t:`value` of a :t:`struct type`.
-
-.. _fls_P7920ALJisrH:
 
 structurally equal
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_glRZUKhmaWmP`
 A :t:`type` is :dt:`structurally equal` when its :t:`[value]s` can be compared
 for equality by structure.
-
-.. _fls_feZ3iDff05Cb:
 
 subexpression
 ^^^^^^^^^^^^^
 
-:dp:`fls_bNSHwD4Kpfm0`
 A :dt:`subexpression` is an :t:`expression` nested within another
 :t:`expression`.
-
-.. _fls_wee9stfk0abp:
 
 subject expression
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xisqke87ert`
 A :dt:`subject expression` is an :t:`expression` that controls
 :t:`[for loop]s`, :t:`[if expression]s`, and :t:`[match expression]s`.
 
-:dp:`fls_gph5doham4js`
 See :s:`SubjectExpression`.
-
-.. _fls_dc5ibvnnhs7e:
 
 subject let expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_b3ckv6zgnaeb`
 A :dt:`subject let expression` is an :t:`expression` that controls
 :t:`[if let expression]s` and :t:`[while let loop]s`.
 
-:dp:`fls_vnzaargh5yok`
 See :s:`SubjectLetExpression`.
-
-.. _fls_k7ro8n23wtdc:
 
 subpattern
 ^^^^^^^^^^
 
-:dp:`fls_942ulj9qsdes`
 A :dt:`subpattern` is a :t:`pattern` nested within another :t:`pattern`.
-
-.. _fls_0hf1gNf90qKr:
 
 subtraction assignment
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_75Eyk2YXO2j4`
 For :dt:`subtraction assignment`, see :t:`subtraction assignment`.
-
-.. _fls_a4iu72zn4h0:
 
 subtraction assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_4pb85nl4r7vs`
 A :dt:`subtraction assignment expression` is a
 :t:`compound assignment expression` that uses subtraction.
 
-:dp:`fls_mye9yj5tc8hr`
 See :s:`SubtractionAssignmentExpression`.
-
-.. _fls_25ru96mfdcsn:
 
 subtraction expression
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_caamjgpw59id`
 A :dt:`subtraction expression` is an :t:`arithmetic expression` that uses
 subtraction.
 
-:dp:`fls_mx3olnbntpye`
 See :s:`SubtractionExpression`.
-
-.. _fls_qw3fn1116se9:
 
 subtrait
 ^^^^^^^^
 
-:dp:`fls_wnj95vozis6n`
 A :dt:`subtrait` is a :t:`trait` with a :t:`supertrait`.
-
-.. _fls_pu4zqJ1tGrfH:
 
 subtype
 ^^^^^^^
 
-:dp:`fls_pmkjOWsieQog`
 A :dt:`subtype` is a :t:`type` with additional constraints.
-
-.. _fls_f5dxz8pvs1kz:
 
 subtyping
 ^^^^^^^^^
 
-:dp:`fls_bo5xzjsdd3lj`
 :dt:`Subtyping` is a property of :t:`[type]s`, allowing one :t:`type` to be
 used where another :t:`type` is expected.
-
-.. _fls_qar9v52smi9j:
 
 suffixed float
 ^^^^^^^^^^^^^^
 
-:dp:`fls_7reb4jp0x1wf`
 A :dt:`suffixed float` is a :t:`float literal` with a :t:`float suffix`.
-
-.. _fls_bmbu11ycjpor:
 
 suffixed integer
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_ltzetxu3sq7k`
 A :dt:`suffixed integer` is an :t:`integer literal` with an :t:`integer suffix`.
-
-.. _fls_12bluakt0jnj:
 
 super public modifier
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_vry5mhs3a5wv`
 A :dt:`super public modifier` is a :t:`visibility modifier` that grants a
 :t:`name` :t:`public visibility` within the parent :t:`module` only.
 
-:dp:`fls_4a1s9bcrk5oy`
 See :s:`SuperPublicModifier`.
-
-.. _fls_1axcyv628aov:
 
 supertrait
 ^^^^^^^^^^
 
-:dp:`fls_s4chur1wutwh`
 A :dt:`supertrait` is a transitive :t:`trait` that a :t:`type` must
 additionally implement.
-
-.. _fls_r4eoz3ohvpdi:
 
 sync type
 ^^^^^^^^^
 
-:dp:`fls_rpc0c8qx3nbo`
 A :dt:`sync type` is a :t:`type` that implements the :std:`core::marker::Sync`
 :t:`trait`.
-
-.. _fls_44djv0wocacs:
 
 syntactic category
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_f981e3m7kq50`
 A :dt:`syntactic category` is a nonterminal in the Backus-Naur Form grammar
 definition of the Rust programming language.
-
-.. _fls_psd2ll10ixs:
 
 tail expression
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_6k873f1knasi`
 A :dt:`tail expression` is the last :t:`expression` within a
 :t:`block expression`.
-
-.. _fls_4omay4i65dwz:
 
 temporary
 ^^^^^^^^^
 
-:dp:`fls_fathkxu9kxvw`
 A :dt:`temporary` is an anonymous :t:`variable` produced by some intermediate
 computation.
-
-.. _fls_ihv02usuziw8:
 
 terminated
 ^^^^^^^^^^
 
-:dp:`fls_med1l8vheb83`
 A :t:`loop expression` is :dt:`terminated` when its :t:`block expression` is no
 longer evaluated.
-
-.. _fls_ef03n3ehz372:
 
 terminated macro invocation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_542es82wfzco`
 A :dt:`terminated macro invocation` is a :t:`macro invocation` that may be used
 as a :t:`statement`.
 
-:dp:`fls_tcvfi2zgdm58`
 See :s:`TerminatedMacroInvocation`.
-
-.. _fls_AVZGZPd6WXXO:
 
 textual macro scope
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xyeYk6vrmlWp`
 A :dt:`textual macro scope` is a :t:`scope` for :t:`[declarative macro]s`.
-
-.. _fls_mdcbhy96hrau:
 
 textual type
 ^^^^^^^^^^^^
 
-:dp:`fls_lv1pdtzf6f58`
 A :dt:`textual type` is a :t:`type` class that includes type :c:`char` and type
 :c:`str`.
-
-.. _fls_lfsgf6u142yb:
 
 thin pointer
 ^^^^^^^^^^^^
 
-:dp:`fls_i2j0u4v5o1bs`
 A :dt:`thin pointer` is a :t:`value` of a :t:`thin pointer type`.
-
-.. _fls_7ksqpi9j8ba9:
 
 thin pointer type
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_33rka3kyxgrk`
 A :dt:`thin pointer type` is an :t:`indirection type` that refers to a
 :t:`fixed sized type`.
-
-.. _fls_tzoko74t5t6n:
 
 token matching
 ^^^^^^^^^^^^^^
 
-:dp:`fls_a19q6lhvakcm`
 :dt:`Token matching` is the process of consuming a :s:`TokenTree` in an attempt
 to fully satisfy a :t:`macro match` of a selected :t:`macro matcher` that
 belongs to a resolved :t:`declarative macro`.
 
-.. _fls_ma3vs7yoj285:
-
 tokens
 ^^^^^^
 
-:dp:`fls_v23kqvyvscd7`
 :dt:`[Token]s` are a subset of :t:`[lexical element]s` consumed by
 :t:`[macro]s`.
-
-.. _fls_cad25qns4164:
 
 trait
 ^^^^^
 
-:dp:`fls_mf4x9g70o5z6`
 A :dt:`trait` is an :t:`item` that describes an interface a :t:`type` can
 implement.
 
-:dp:`fls_ypjhwvuyrns`
 See :s:`TraitDeclaration`.
-
-.. _fls_5hNydsQDrICq:
 
 trait body
 ^^^^^^^^^^
 
-:dp:`fls_u221Me58aZmY`
 A :dt:`trait body` is a :t:`construct` that encapsulates the
 :t:`[associated item]s`, :t:`[inner attribute]s`, and
 :t:`[inner doc comment]s` of a :t:`trait`.
 
-:dp:`fls_dITFx04TB4h0`
 See :s:`TraitBody`.
-
-.. _fls_868cgnb1soeh:
 
 trait bound
 ^^^^^^^^^^^
 
-:dp:`fls_95zx8unuxxpq`
 A :dt:`trait bound` is a :t:`bound` that imposes a constraint on the
 :t:`[trait]s` of :t:`[generic parameter]s`.
 
-:dp:`fls_bkbym8v4t6oh`
 See :s:`TraitBound`.
-
-.. _fls_kflieu6uottg:
 
 trait implementation
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_5v7kbg144pr8`
 A :dt:`trait implementation` is an :t:`implementation` that adds functionality
 specified by a :t:`trait`.
 
-:dp:`fls_rytylyyxh27f`
 See :s:`TraitImplementation`.
-
-.. _fls_TCIzYoMeGtub:
 
 trait object lifetime elision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rALP9b6qjlp9`
 :dt:`Trait object lifetime elision` is a form of :t:`lifetime elision` that
 applies to :t:`[trait object type]s`.
-
-.. _fls_7qtbro7ipndr:
 
 trait object type
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lo2fzzdwxy1l`
 A :dt:`trait object type` is a :t:`type` that implements a :t:`trait`, where
 the :t:`type` is not known at compile time.
 
-:dp:`fls_d632mc5c8qwt`
 See :s:`TraitObjectTypeSpecification`,
 :s:`TraitObjectTypeSpecificationOneBound`.
-
-.. _fls_nfdfeFVZRC5F:
 
 trait type
 ^^^^^^^^^^
 
-:dp:`fls_JQsQnQ0dTHlS`
 A :dt:`trait type` is either an :t:`impl trait type` or a
 :t:`trait object type`.
-
-.. _fls_sl62718i1kkn:
 
 transparent representation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hb3e72rhzpnv`
 :dt:`Transparent representation` is a :t:`type representation` that applies
 only to an :t:`enum type` with a single :t:`enum variant` or a :t:`struct type`
 where the :t:`struct type` or :t:`enum variant` has a single :t:`field` of
 non-zero :t:`size` and any number of :t:`[field]s` of :t:`size` zero and
 :t:`alignment` one.
 
-.. _fls_soqkluvirlsd:
-
 trivial predicate
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_db5njwrjolhs`
 A :dt:`trivial predicate` is a :t:`where clause predicate` that does not use
 the :t:`[generic parameter]s` or :t:`[higher-ranked trait bound]s` of the related
 :t:`construct`.
 
-.. _fls_si70t19ox07e:
-
 tuple
 ^^^^^
 
-:dp:`fls_yhcfqz6p0059`
 A :dt:`tuple` is a :t:`value` of a :t:`tuple type`.
-
-.. _fls_1XEHpJOK9DKB:
 
 tuple enum variant
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_eduQhUYBEkVx`
 A :dt:`tuple enum variant` is an :t:`enum variant` with a
 :s:`TupleStructFieldList`.
-
-.. _fls_sP7uHoLxGfRO:
 
 tuple enum variant value
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ORURxipGqNrZ`
 A :dt:`tuple enum variant value` is a :t:`value` of a :t:`tuple enum variant`.
-
-.. _fls_udl6ujjg1jae:
 
 tuple expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_x7m4u1dx4eli`
 A :dt:`tuple expression` is an :t:`expression` that constructs a :t:`tuple`.
 
-:dp:`fls_qawnvcddgyxx`
 See :s:`TupleExpression`.
-
-.. _fls_bf1v4e1s5xj6:
 
 tuple field
 ^^^^^^^^^^^
 
-:dp:`fls_8rq1gbzij5tk`
 A :dt:`tuple field` is a :t:`field` of a :t:`tuple type`.
-
-.. _fls_zfvvbf7ncrhj:
 
 tuple initializer
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_94hg6re11zl5`
 A :dt:`tuple initializer` is an :t:`operand` that provides the :t:`value` of a
 :t:`tuple field` in a :t:`tuple expression`.
-
-.. _fls_7f2sx37kg4ca:
 
 tuple pattern
 ^^^^^^^^^^^^^
 
-:dp:`fls_al2q3vh1rg6e`
 A :dt:`tuple pattern` is a :t:`pattern` that matches a :t:`tuple` which
 satisfies all criteria defined by its :t:`[subpattern]s`.
 
-:dp:`fls_bevmt5t0238j`
 See :s:`TuplePattern`.
-
-.. _fls_245idp9hpqf6:
 
 tuple struct
 ^^^^^^^^^^^^
 
-:dp:`fls_pdcpmapiq491`
 A :dt:`tuple struct` is a :t:`struct` with a :s:`TupleStructFieldList`.
 
-:dp:`fls_1tj4p05m4wdf`
 See :s:`TupleStructDeclaration`.
-
-.. _fls_UYCpeq4Z87My:
 
 tuple struct call expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_DQaCUkskfXzk`
 A :dt:`tuple struct call expression` is a :t:`call expression` where the
 :t:`call operand` resolves to a :t:`tuple struct` or a :t:`tuple enum variant`.
-
-.. _fls_xx4slbg8s63e:
 
 tuple struct field
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ndeb1a2hm9d8`
 A :dt:`tuple struct field` is a :t:`field` of a :t:`tuple struct type`.
 
-:dp:`fls_v4eq8xg608d5`
 See :s:`TupleStructField`.
-
-.. _fls_u2j18nl1t12f:
 
 tuple struct pattern
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_gu1mfurivnfz`
 A :dt:`tuple struct pattern` is a :t:`pattern` that matches a
 :t:`tuple enum variant value` or a :t:`tuple struct value`.
 
-:dp:`fls_3jx5683mdm10`
 See :s:`TupleStructPattern`.
-
-.. _fls_qx8j2lvqigqk:
 
 tuple struct type
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hhikx5ajx3bl`
 A :dt:`tuple struct type` is the :t:`type` of a :t:`tuple struct`.
-
-.. _fls_x4ALCJKhVDZF:
 
 tuple struct value
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_xz1p4pss2Ocn`
 A :dt:`tuple struct value` is a :t:`value` of a :t:`tuple struct type`.
-
-.. _fls_k4yz7i2pf9wp:
 
 tuple type
 ^^^^^^^^^^
 
-:dp:`fls_q0ulqfvnxwni`
 A :dt:`tuple type` is a :t:`sequence type` that represents a heterogeneous list
 of other :t:`[type]s`.
 
-:dp:`fls_rkugxsau1w78`
 See :s:`TupleTypeSpecification`.
-
-.. _fls_wzupssn435n:
 
 type
 ^^^^
 
-:dp:`fls_nhlh7vvgsbwo`
 A :dt:`type` defines a set of :t:`[value]s` and a set of operations that act on
 those :t:`[value]s`.
-
-.. _fls_vaklivoy2ix2:
 
 type alias
 ^^^^^^^^^^
 
-:dp:`fls_8pcsxodv1xp5`
 A :dt:`type alias` is an :t:`item` that defines a :t:`name` for a :t:`type`.
 
-:dp:`fls_qfzskp1t3h5w`
 See :s:`TypeAliasDeclaration`.
-
-.. _fls_89ollsdjx3uy:
 
 type argument
 ^^^^^^^^^^^^^
 
-:dp:`fls_152lk7hrtd11`
 A :dt:`type argument` is a :t:`generic argument` that supplies the :t:`value`
 of a :t:`type parameter`.
 
-:dp:`fls_91tqk65qiygf`
 See :s:`TypeArgument`.
-
-.. _fls_1n50v16et5e6:
 
 type ascription
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_pm5jytclqn7y`
 A :dt:`type ascription` specifies the :t:`type` of a :t:`construct`.
 
-:dp:`fls_c3xtiputfxea`
 See :s:`TypeAscription`.
-
-.. _fls_zDdXv5I4bW9H:
 
 type bound predicate
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_j6WKoybB4cep`
 A :dt:`type bound predicate` is a :t:`construct` that specifies
 :t:`[lifetime bound]s` and :t:`[trait bound]s` on a :t:`type`.
 
-:dp:`fls_oMlPNgoDjnoW`
 See :s:`TypeBoundPredicate`.
-
-.. _fls_k24jb967nu1q:
 
 type cast expression
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_j6zo3rir1x76`
 A :dt:`type cast expression` is an :t:`expression` that changes the :t:`type`
 of an :t:`operand`.
 
-:dp:`fls_dvh1xy9w74ch`
 See :s:`TypeCastExpression`.
-
-.. _fls_6j08yuafv0vl:
 
 type coercion
 ^^^^^^^^^^^^^
 
-:dp:`fls_mt36qehtqova`
 :dt:`Type coercion` is an implicit operation that changes the :t:`type` of
 a :t:`value`.
-
-.. _fls_7fpvb2gvqng8:
 
 type inference
 ^^^^^^^^^^^^^^
 
-:dp:`fls_ky8epvf9834e`
 :dt:`Type inference` is the process of deducing the expected :t:`type` of an
 arbitrary :t:`value`.
-
-.. _fls_0jri0m3F1fAT:
 
 type inference root
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_hLI7lCixs48z`
 A :dt:`type inference root` is a :t:`construct` whose inner :t:`[expression]s`
 and :t:`[pattern]s` are subject to :t:`type inference` independently of other
 :t:`[type inference root]s`.
 
-.. _fls_uv2damik654e:
-
 type parameter
 ^^^^^^^^^^^^^^
 
-:dp:`fls_5t6510wkb67x`
 A :dt:`type parameter` is a :t:`generic parameter` for a :t:`type`.
 
-:dp:`fls_vquy0tsvd93x`
 See :s:`TypeParameter`.
-
-.. _fls_Fq2zTHYRpK2V:
 
 type parameter initializer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Xpz47JLNsOXI`
 A :dt:`type parameter initializer` is a :t:`construct` that provides the
 default :t:`value` of its related :t:`type parameter`.
 
-:dp:`fls_6Ap26AcSadP8`
 See :s:`TypeParameterInitializer`.
-
-.. _fls_HghjWqvyj5bN:
 
 type parameter type
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_EuHHxwHd0RHV`
 A :dt:`type parameter type` is a placeholder :t:`type` of a :t:`type parameter`
 to be substituted by :t:`generic substitution`.
-
-.. _fls_QDCiXh7uSj9r:
 
 type path
 ^^^^^^^^^
 
-:dp:`fls_UBR5czHrMTrx`
 A :dt:`type path` is a :t:`path` that acts as a :t:`type specification`.
 
-:dp:`fls_7CbNAZYSZayW`
 See :s:`TypePath`.
-
-.. _fls_wa3biT0rQ102:
 
 type path resolution
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Xv6JbfdIyvA3`
 :dt:`Type path resolution` is a form of :t:`path resolution` that applies to
 a :t:`type path`.
-
-.. _fls_u1zkh2m8p92:
 
 type representation
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_rv80nyxwj2z8`
 :dt:`Type representation` specifies the :t:`layout` of :t:`[field]s` of
 :t:`[abstract data type]s`.
-
-.. _fls_ukua6gbye6ot:
 
 type specification
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tdjhjg9zhnv5`
 A :dt:`type specification` describes the structure of a :t:`type`.
 
-:dp:`fls_a3sqjp1l8po6`
 See :s:`TypeSpecification`.
-
-.. _fls_qoehu9p00q56:
 
 type unification
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_3vyodut341b5`
 :dt:`Type unification` is the process by which :t:`type inference` propagates
 known :t:`[type]s` across the :t:`type inference root` and assigns concrete
 :t:`[type]s` to :t:`[type variable]s`, as well as a general mechanism to check
 for compatibility between two :t:`[type]s` during :t:`method resolution`.
 
-.. _fls_6zhffgxtytku:
-
 type variable
 ^^^^^^^^^^^^^
 
-:dp:`fls_j9eusnwze4rz`
 A :dt:`type variable` is a placeholder used during :t:`type inference` to stand
 in for an undetermined :t:`type` of an :t:`expression` or a :t:`pattern`.
-
-.. _fls_44uvj9l7q98z:
 
 u8
 ^^
 
-:dp:`fls_umf9zfeghy6`
 :dc:`u8` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`8` - 1, all inclusive.
-
-.. _fls_eh24kdjdze5j:
 
 u16
 ^^^
 
-:dp:`fls_8vi7bm2895y0`
 :dc:`u16` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`16` - 1, all inclusive.
-
-.. _fls_jybcgdujzpqy:
 
 u32
 ^^^
 
-:dp:`fls_pw90erui8vkk`
 :dc:`u32` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`32` - 1, all inclusive.
-
-.. _fls_1z1e3chuejzz:
 
 u64
 ^^^
 
-:dp:`fls_pbcmhznqft9m`
 :dc:`u64` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`64` - 1, all inclusive.
-
-.. _fls_5hn9e3ce1smp:
 
 u128
 ^^^^
 
-:dp:`fls_8yv891ur2av5`
 :dc:`u128` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`128` - 1, all inclusive.
-
-.. _fls_p032easjag3d:
 
 unary operator
 ^^^^^^^^^^^^^^
 
-:dp:`fls_p6mk2zrwgwem`
 A :dt:`unary operator` operates on one :t:`operand`.
-
-.. _fls_WuLL4SvSKavZ:
 
 undefined behavior
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_WpwmltUMQGZa`
 :dt:`Undefined behavior` is a situation that results in an unbounded error.
-
-.. _fls_X6XjWwYeTnVR:
 
 under resolution
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_BppwXSVUWtEu`
 A :t:`construct` that is being resolved is said to be :dt:`under resolution`.
-
-.. _fls_57kis2vnt3cv:
 
 underscore expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ukl1sefb99gj`
 An :dt:`underscore expression` is an :t:`expression` that acts as a placeholder
 in a :t:`destructuring assignment`.
 
-:dp:`fls_qbo267kdjcgs`
 See :s:`UnderscoreExpression`.
-
-.. _fls_fhwqe6afup2o:
 
 underscore pattern
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_f6yroesif1q4`
 An :dt:`underscore pattern` is a :t:`pattern` that matches any single
 :t:`value`.
 
-:dp:`fls_bktuchv7o4dd`
 See :s:`UnderscorePattern`.
-
-.. _fls_HpUSWMvNS5f4:
 
 unhygienic
 ^^^^^^^^^^
 
-:dp:`fls_0t4lFZLkNieR`
 An :t:`identifier` is :dt:`unhygienic` when it has :t:`call site hygiene`.
-
-.. _fls_kafgmevvzl5t:
 
 Unicode
 ^^^^^^^
 
-:dp:`fls_y7gwku7pe1f4`
 :dt:`Unicode` is the universal character encoding standard for written
 characters and text described in the Unicode® Standard by the Unicode
 Consortium.
 
-.. _fls_y7m6AentM6Ik:
-
 unifiable
 ^^^^^^^^^
 
-:dp:`fls_01BNTCL4u8Gn`
 For :dt:`unifiable`, see :t:`unify`.
-
-.. _fls_u03p4rvz1jhs:
 
 unifiable types
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_jsbggfitv9xk`
 Two :t:`[type]s` that :t:`unify` are said to be :dt:`[unifiable type]s`.
-
-.. _fls_9RfuDiI6qrzZ:
 
 unified type
 ^^^^^^^^^^^^
 
-:dp:`fls_tqRwIe6z3a4j`
 A :dt:`unified type` is a :t:`type` produced by :t:`type unification`.
-
-.. _fls_da6ssnmmsevo:
 
 unify
 ^^^^^
 
-:dp:`fls_mango4gffb9e`
 A :t:`type` is said to :dt:`unify` with another type when the domains, ranges,
 and structures of both :t:`[type]s` are compatible.
-
-.. _fls_8qljy9e1jjcb:
 
 union
 ^^^^^
 
-:dp:`fls_x3oibk39dvem`
 A :dt:`union` is an :t:`item` that declares a :t:`union type`.
-
-.. _fls_71xvazpwi8p0:
 
 union field
 ^^^^^^^^^^^
 
-:dp:`fls_6t2fbnlndz8y`
 A :dt:`union field` is a :t:`field` of a :t:`union type`.
-
-.. _fls_nrgyga1rztb3:
 
 union type
 ^^^^^^^^^^
 
-:dp:`fls_af2sscrep7mc`
 A :dt:`union type` is an :t:`abstract data type` similar to a :t:`C`-like union.
 
-:dp:`fls_fgvjogfz8ink`
 See :s:`UnionDeclaration`.
-
-.. _fls_2QRQMeA3OSVl:
 
 union value
 ^^^^^^^^^^^
 
-:dp:`fls_9BPrxky3a4nE`
 A :dt:`union value` is a :t:`value` of a :t:`union type`.
-
-.. _fls_Is9hWLC6Q0g5:
 
 unique immutable reference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_eXrivAmNxzmv`
 A :dt:`unique immutable reference` is an :t:`immutable reference` produced by
 :t:`capturing` what is asserted to be the only live :t:`reference` to a
 :t:`value` while the :t:`reference` exists.
 
-.. _fls_Rwtgq904NoaL:
-
 unit enum variant
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_y6fI5L3Tghie`
 A :dt:`unit enum variant` is an :t:`enum variant` without a :t:`field list`.
-
-.. _fls_f3hmx9qya258:
 
 unit struct
 ^^^^^^^^^^^
 
-:dp:`fls_9t7fu8fcak6k`
 A :dt:`unit struct` is a :t:`struct` without a :t:`field list`.
 
-:dp:`fls_mSuiysAVczPx`
 See :s:`UnitStructDeclaration`.
-
-.. _fls_jdvEnl8F7I8R:
 
 unit struct constant
 ^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_lLGn4JqddeAg`:
 A :dt:`unit struct constant` is a :t:`constant` implicitly created by a
 :t:`unit struct`.
-
-.. _fls_6j2wnOmBILJa:
 
 unit struct type
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_oIzmvACNeQpE`
 A :dt:`unit struct type` is the :t:`type` of a :t:`unit struct`.
-
-.. _fls_CXp8fgPrBVUe:
 
 unit struct value
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_Kr9nGIjx3N4R`
 A :dt:`unit struct value` is a :t:`value` of a :t:`unit struct type`.
-
-.. _fls_wmn9mcqae88q:
 
 unit tuple
 ^^^^^^^^^^
 
-:dp:`fls_vo1jw6rmu4yy`
 A :dt:`unit tuple` is a :t:`value` of the :t:`unit type`.
-
-.. _fls_t32yfzmpid5a:
 
 unit type
 ^^^^^^^^^
 
-:dp:`fls_jtdtv3q2ls05`
 The :dt:`unit type` is a :t:`tuple type` of zero :t:`arity`.
-
-.. _fls_vxt0ifseehv9:
 
 unit value
 ^^^^^^^^^^
 
-:dp:`fls_ycdv4nvsdyx`
 The :dt:`unit value` is the :t:`value` of a :t:`unit type`.
-
-.. _fls_u78ng1tleh0w:
 
 unnamed constant
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_ufj01cxxsv1w`
 An :dt:`unnamed constant` is a :t:`constant` declared with character 0x5F (low
 line).
-
-.. _fls_r8567aozbyxl:
 
 unnamed lifetime
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_4iy6zpq66mit`
 An :dt:`unnamed lifetime` is a :t:`lifetime` declared with character 0x5F (low
 line).
-
-.. _fls_cDVmvrVhUBmr:
 
 unqualified path expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_9xKgP8uVsOaR`
 An :dt:`unqualified path expression` is a :t:`path expression`  without a :t:`qualified type`.
-
-.. _fls_6349nvapfj9d:
 
 unsafe block
 ^^^^^^^^^^^^
 
-:dp:`fls_8tkolhmd6xfp`
 For :dt:`unsafe block`, see :t:`unsafe block expression`.
-
-.. _fls_u8sdp2fxz9pn:
 
 unsafe block expression
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_et2h89jyivhs`
 An :dt:`unsafe block expression` is a :t:`block expression` that is specified
 with :t:`keyword` ``unsafe``.
 
-:dp:`fls_c94rudunhp5b`
 See :s:`UnsafeBlockExpression`.
-
-.. _fls_5m85wlr2qw78:
 
 unsafe context
 ^^^^^^^^^^^^^^
 
-:dp:`fls_qn1s845ejbu0`
 An :dt:`unsafe context` is either an :t:`unsafe block` or an
 :t:`unsafe function`.
-
-.. _fls_pre02nas9dad:
 
 unsafe external block
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_pkfgas34msas`
 An :dt:`unsafe external block` is an :t:`external block` subject to keyword ``unsafe``.
-
-.. _fls_ua64pv82skaw:
 
 unsafe function
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_2ht13dgtxi1o`
 An :dt:`unsafe function` is a :t:`function` subject to :t:`keyword` ``unsafe``.
-
-.. _fls_y1iruf62p856:
 
 unsafe function item type
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_r91tuwi55nu7`
 An :dt:`unsafe function item type` is a :t:`function item type` where the
 related :t:`function` is an :t:`unsafe function`.
-
-.. _fls_bokqlokua059:
 
 unsafe function pointer type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_tiluwa2v4l6d`
 An :dt:`unsafe function pointer type` is a function pointer type subject to
 :t:`keyword` ``unsafe``.
-
-.. _fls_e2wyfbem6vwn:
 
 unsafe operation
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_34h60ubicgsj`
 An :dt:`unsafe operation` is an operation that may result in
 :t:`undefined behavior` that is not diagnosed as a static error.
 :t:`[Unsafe operation]s` are referred to as :t:`unsafe Rust`.
 
-.. _fls_4f6mppoenj3b:
-
 unsafe Rust
 ^^^^^^^^^^^
 
-:dp:`fls_30asi010yf1a`
 For :dt:`unsafe Rust`, see :t:`[unsafe operation]s`.
-
-.. _fls_38ae1t48h9cb:
 
 unsafe trait
 ^^^^^^^^^^^^
 
-:dp:`fls_w6zlsf2ye457`
 An :dt:`unsafe trait` is a :t:`trait` subject to :t:`keyword` ``unsafe``
-
-.. _fls_h62dfjfyqcbn:
 
 unsafe trait implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_kqwcv076dzie`
 An :dt:`unsafe trait implementation` is a :t:`trait implementation` subject to
 :t:`keyword` ``unsafe``.
-
-.. _fls_pst7yov6vnr9:
 
 unsafety
 ^^^^^^^^
 
-:dp:`fls_742ycx5181n`
 :dt:`Unsafety` is the presence of :t:`[unsafe operation]s` in program text.
-
-.. _fls_4jc74lz245z3:
 
 unsigned integer type
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_dxnf79qemlg6`
 An :dt:`unsigned integer type` is an :t:`integer type` whose :t:`[value]s`
 denote zero and positive whole numbers.
-
-.. _fls_pjup0piqlxe3:
 
 unsized coercion
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_olt5qhyvhmtq`
 An :dt:`unsized coercion` is a :t:`type coercion` that converts a
 :t:`sized type` into an :t:`unsized type`.
-
-.. _fls_KiVgO7I3UUhh:
 
 unsized type
 ^^^^^^^^^^^^
 
-:dp:`fls_M9NpzBH8Wf4z`
 An :dt:`unsized type` is a :t:`type` with statically unknown size.
-
-.. _fls_4ph9cact2scc:
 
 unsuffixed float
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_7wp6y0xeqqve`
 An :dt:`unsuffixed float` is a :t:`float literal` without a :t:`float suffix`.
-
-.. _fls_d18nctsj8wu5:
 
 unsuffixed integer
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_t419z3zder0q`
 An :dt:`unsuffixed integer` is an :t:`integer literal` without an
 :t:`integer suffix`.
-
-.. _fls_Z8qvOkP4Zfj5:
 
 use capture
 ^^^^^^^^^^^
 
-:dp:`fls_eZyPXG27Zwcg`
 An :dt:`use capture` is a :t:`generic parameter` referenced via keyword $$use$$ within an :t:`anonymous return type`.
 
-:dp:`fls_Z8qvOkP4Zfj5`
 See :s:`UseCaptures`.
-
-.. _fls_fow1bnvduafi:
 
 use import
 ^^^^^^^^^^
 
-:dp:`fls_uccv9zthh5vt`
 A :dt:`use import` brings :t:`entities <entity>` :t:`in scope` within the
 :t:`block expression` of an :t:`expression-with-block` or :t:`module` where the
 :t:`use import` resides.
 
-:dp:`fls_ib5wf62j4uhr`
 See :s:`UseImport`.
-
-.. _fls_gvjm5mms9ahz:
 
 usize
 ^^^^^
 
-:dp:`fls_r22k1l8799k6`
 :dc:`usize` is an :t:`unsigned integer type` with the same number of bits as
 the platform's :t:`pointer type`, and is at least 16-bits wide.
-
-.. _fls_A5K8aOBsI3BG:
 
 validity invariant
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_3ebC3l839ajF`
 A :dt:`validity invariant` is an invariant that when violated results in
 immediate :t:`undefined behavior`.
-
-.. _fls_tg866bc926ms:
 
 value
 ^^^^^
 
-:dp:`fls_h8jn338b51yu`
 A :dt:`value` is either a :t:`literal` or the result of a computation, that may
 be stored in a memory location, and interpreted based on some :t:`type`.
-
-.. _fls_h03noz6jzpyl:
 
 value expression
 ^^^^^^^^^^^^^^^^
 
-:dp:`fls_mn6tcuz5j3p`
 A :dt:`value expression` is an :t:`expression` that represents a :t:`value`.
-
-.. _fls_7xiaXXSwy4GP:
 
 value expression context
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_NGGZEbmoLRbD`
 A :dt:`value expression context` is an expression context that is not a
 :t:`place expression context`.
-
-.. _fls_a5xof9jlpc2e:
 
 value operand
 ^^^^^^^^^^^^^
 
-:dp:`fls_x4seemjknk2z`
 A :dt:`value operand` is an :t:`operand` that supplies the :t:`value` that is
 assigned to an :t:`assignee operand` by an :t:`assignment expression`.
 
-:dp:`fls_cl4fakfkpscp`
 See :s:`ValueOperand`.
-
-.. _fls_donq6w1906lw:
 
 variable
 ^^^^^^^^
 
-:dp:`fls_9ab12k4vwsio`
 A :dt:`variable` is a placeholder for a :t:`value` that is allocated on the
 stack.
-
-.. _fls_RIe80XOF8VlA:
 
 variadic part
 ^^^^^^^^^^^^^
 
-:dp:`fls_ePnTyLoqJ1i7`
 A :dt:`variadic part` indicates the presence of :t:`C`-like optional
 parameters.
 
-:dp:`fls_z9D86gBFbKB5`
 See :s:`VariadicPart`.
-
-.. _fls_q0xplb4tbzpq:
 
 variance
 ^^^^^^^^
 
-:dp:`fls_il0krrsf09f8`
 :dt:`Variance` is a property of :t:`[lifetime parameter]s` and
 :t:`[type parameter]s` that describes the circumstances under which a
 :t:`generic type` is a :t:`subtype` of an instantiation of itself with
 different :t:`[generic argument]s`.
 
-.. _fls_svx87y4p8fdx:
-
 visibility
 ^^^^^^^^^^
 
-:dp:`fls_sadmsqhptlho`
 :dt:`Visibility` is a property of :t:`[field]s` and :t:`[item]s` that determines
 which :t:`[module]s` can refer to the :t:`name` of the :t:`field` or :t:`item`.
-
-.. _fls_xqjk8avt7t51:
 
 visibility modifier
 ^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_ze7befho4jhs`
 A :dt:`visibility modifier` sets the :t:`visibility` of the :t:`name` of an
 :t:`item`.
-
-.. _fls_dLlUt8PrXAls:
 
 visible emptiness
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_shXDYqnUy2Pb`
 :dt:`Visible emptiness <visible emptiness>` is a property of :t:`[type]s` and :t:`[enum variant]s` that have no :t:`[value]s` that are fully observable.
-
-.. _fls_EnT5zRuwviWM:
 
 visible empty enum variant
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_MQiPWNwdk95I`
 A :dt:`visible empty enum variant` is an :t:`enum variant` subject to :t:`visible emptiness`.
-
-.. _fls_HYWQ0lJS3TET:
 
 visible empty type
 ^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_OLVD0u9w68Gl`
 A :dt:`visible empty type` is a :t:`type` subject to :t:`visible emptiness`.
-
-.. _fls_iplp3gvfbcpw:
 
 weak keyword
 ^^^^^^^^^^^^
 
-:dp:`fls_4hiznltf5wlu`
 A :dt:`weak keyword` is a :t:`keyword` whose special meaning depends on the
 context.
 
-:dp:`fls_psah573fsrig`
 See :s:`WeakKeyword`.
-
-.. _fls_ew2gsg72rjxk:
 
 where clause
 ^^^^^^^^^^^^
 
-:dp:`fls_prljyrhontzn`
 A :dt:`where clause` is a :t:`construct` that specifies :t:`[bound]s` on
 :t:`[lifetime parameter]s` and :t:`[type parameter]s`.
 
-:dp:`fls_k32hnug33eo9`
 See :s:`WhereClause`.
-
-.. _fls_myNeYCm4VI0R:
 
 where clause predicate
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_0LACQVmZpDQF`
 A :dt:`where clause predicate` is either a :t:`lifetime bound predicate` or a
 :t:`type bound predicate`.
 
-:dp:`fls_Jk7V1SOKE4Gm`
 See :s:`WhereClausePredicate`.
-
-.. _fls_8hcsablipi17:
 
 while let loop
 ^^^^^^^^^^^^^^
 
-:dp:`fls_ovutw52qtx71`
 For :dt:`while let loop`, see :t:`while let loop expression`.
-
-.. _fls_gme4odk59x6d:
 
 while let loop expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_g35gn7n88acp`
 A :dt:`while let loop expression` is a :t:`loop expression` that continues to
 evaluate its :t:`loop body` as long as its :t:`subject let expression` yields a
 :t:`value` that can be matched against its :t:`pattern`.
 
-:dp:`fls_q3jcb4nodqba`
 See :s:`WhileLetLoopExpression`.
-
-.. _fls_od59yim9kasi:
 
 while loop
 ^^^^^^^^^^
 
-:dp:`fls_ug9cxoml9ged`
 For :dt:`while loop`, see :t:`while loop expression`.
-
-.. _fls_1qxi3h3qmgso:
 
 while loop expression
 ^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_fq0zyup4djyh`
 A :dt:`while loop expression` is a :t:`loop expression` that continues to
 evaluate its :t:`loop body` as long as its :t:`iteration expression` holds
 true.
 
-:dp:`fls_7htwpbmyq83u`
 See :s:`WhileLoopExpression`.
-
-.. _fls_cxm8nw6qiryr:
 
 whitespace string
 ^^^^^^^^^^^^^^^^^
 
-:dp:`fls_nljkmadklwdp`
 A :dt:`whitespace string` is a string that consists of one or more
 :t:`[whitespace character]s`.
-
-.. _fls_a5lrxgucl3be:
 
 zero-sized type
 ^^^^^^^^^^^^^^^
 
-:dp:`fls_rmd6pearrhr8`
 A :dt:`zero-sized type` is a :t:`fixed sized type` with :t:`size` zero.
-
-.. _fls_pix563lfbpm:
 
 zero-variant enum type
 ^^^^^^^^^^^^^^^^^^^^^^
 
-:dp:`fls_84gqz3vwi5mj`
 A :dt:`zero-variant enum type` is an :t:`enum type` without any
 :t:`[enum variant]s`.


### PR DESCRIPTION
The glossary is an informational document, and there is no need for it to have section and paragraph ids. These ids are more useful for the normative text, which needs to be referenced by tests and therefore needs to be stable even if names of terms change.

This change is in preparation for automatically generating glossary chapter, instead of maintaining it manually, which risks resulting in mismatches with main text. To make our lives more easy, we have decided to remove these ids, because we would otherwise have to keep track of them and keep them stable, as well as generate fresh ones as needed.

See rust-lang/fls#680.