### PR TITLE
document preservation of padding in operations on pointers

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -33,6 +33,13 @@ Language changes in Rust 1.95.0
   - The target is outside the scope of the FLS.
 
 - `const-eval: be more consistent in the behavior of padding during typed copies <https://github.com/rust-lang/rust/pull/148967>`_
+
+  New paragraphs:
+
+  - :p:`fls_LmPbrh0Cba8g`
+  - :p:`fls_nwgIMLkvD2Ol`
+  - :p:`fls_hOIImCr1c6IF`
+
 - `Const blocks are no longer evaluated to determine if expressions involving fallible operations can implicitly be constant-promoted <https://github.com/rust-lang/rust/pull/150557>`_
 - `Make operational semantics of pattern matching independent of crate and module <https://github.com/rust-lang/rust/pull/150681>`_
 

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -341,6 +341,8 @@ control reaches the invocation of :t:`macro` :std:`core::panic`.
 It is a static error if the evaluation of a :t:`constant expression` results in
 a :t:`value` that is unaligned.
 
+.. rubric:: Undefined Behavior
+
 :dp:`fls_hOIImCr1c6IF`
 It is undefined behavior to convert a :t:`pointer` that has :t:`provenance` into a non-:t:`pointer type` in a :t:`constant context`.
 

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -341,6 +341,9 @@ control reaches the invocation of :t:`macro` :std:`core::panic`.
 It is a static error if the evaluation of a :t:`constant expression` results in
 a :t:`value` that is unaligned.
 
+:dp:`fls_hOIImCr1c6IF`
+In a :t:`constant context`, it is undefined behavior to convert a :t:`pointer` that has :t:`provenance` into a non-pointer type.
+
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_tg0kya5125jt`

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -342,7 +342,7 @@ It is a static error if the evaluation of a :t:`constant expression` results in
 a :t:`value` that is unaligned.
 
 :dp:`fls_hOIImCr1c6IF`
-In a :t:`constant context`, it is undefined behavior to convert a :t:`pointer` that has :t:`provenance` into a non-pointer type.
+It is undefined behavior to convert a :t:`pointer` that has :t:`provenance` into a non-:t:`pointer type` in a :t:`constant context`.
 
 .. rubric:: Dynamic Semantics
 

--- a/src/values.rst
+++ b/src/values.rst
@@ -111,6 +111,12 @@ The :t:`expression` of a :t:`constant initializer` shall be a
 The value of a :t:`constant` is determined by evaluating its
 :t:`constant initializer`.
 
+:dp:`fls_LmPbrh0Cba8g`
+The representation of the value of a :t:`constant initializer` or :t:`static initializer` must only contain bytes with :t:`provenance` where all bytes of some original :t:`pointer` are in the correct order.
+
+:dp:`fls_nwgIMLkvD2Ol`
+:dt:`Provenance` is the memory that a :t:`pointer` has permission to access, the timespan during which it can acesss that memory, and if it can access the memory for writes.
+
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_xezt9hl069h4`

--- a/src/values.rst
+++ b/src/values.rst
@@ -112,7 +112,7 @@ The value of a :t:`constant` is determined by evaluating its
 :t:`constant initializer`.
 
 :dp:`fls_LmPbrh0Cba8g`
-The representation of the value of a :t:`constant initializer` or :t:`static initializer` must only contain bytes with :t:`provenance` where all bytes of some original :t:`pointer` are in the correct order.
+The :t:`representation` of the :t:`value` of a :t:`constant initializer` or :t:`static initializer` must only contain bytes with :t:`provenance` where all bytes of some original :t:`pointer` are in the correct order.
 
 :dp:`fls_nwgIMLkvD2Ol`
 :dt:`Provenance` is the memory that a :t:`pointer` has permission to access, the timespan during which it can acesss that memory, and if it can access the memory for writes.

--- a/src/values.rst
+++ b/src/values.rst
@@ -112,7 +112,7 @@ The value of a :t:`constant` is determined by evaluating its
 :t:`constant initializer`.
 
 :dp:`fls_LmPbrh0Cba8g`
-The :t:`representation` of the :t:`value` of a :t:`constant initializer` or :t:`static initializer` must only contain bytes with :t:`provenance` where all bytes of some original :t:`pointer` are in the correct order.
+The :t:`type representation` of the :t:`value` of a :t:`constant initializer` or :t:`static initializer` must only contain bytes with :t:`provenance` where all bytes of some original :t:`pointer` are in the correct order.
 
 :dp:`fls_nwgIMLkvD2Ol`
 :dt:`Provenance` is the memory that a :t:`pointer` has permission to access, the timespan during which it can acesss that memory, and if it can access the memory for writes.


### PR DESCRIPTION
This is as far as I "understand" these things, and is based on these 2 PRs
- https://github.com/rust-lang/reference/pull/2091
- https://github.com/rust-lang/reference/pull/2138