### PR TITLE
separate structure demo from parent chapter

### DIFF
--- a/src/general.rst
+++ b/src/general.rst
@@ -144,6 +144,11 @@ listed below, which is informative:
 :dp:`fls_xgk91jrbpyoc`
 All appendices are informative.
 
+.. _fls_qfiIJmBBvelU:
+
+Subchapter segments
+^^^^^^^^^^^^^^^^^^^
+
 :dp:`fls_jc4upf6685bw`
 Each chapter is divided into subchapters that have a common structure. Each
 chapter and subchapter is then organized to include the following segments as is


### PR DESCRIPTION
This places examples at a lower level than the parent chapter to make it more clear they are a demonstration.

r? @PLeVasseur 